### PR TITLE
fix: left nav re-render

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import WithAppContainers from 'containers';
 import theme from 'styles/theme';
 
 import Layout from 'sections/shared/Layout';
+import AppLayout from 'sections/shared/Layout/AppLayout';
 import { MediaContextProvider } from 'styles/media';
 import { QueryCache, ReactQueryCacheProvider } from 'react-query';
 import { DEFAULT_REQUEST_REFRESH_INTERVAL } from 'constants/defaults';
@@ -61,7 +62,9 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
 							<ReactQueryCacheProvider queryCache={queryCache}>
 								<Layout>
 									<SystemStatus>
-										<Component {...pageProps} />
+										<AppLayout>
+											<Component {...pageProps} />
+										</AppLayout>
 									</SystemStatus>
 								</Layout>
 								<ReactQueryDevtools />

--- a/pages/earn.tsx
+++ b/pages/earn.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { StatsSection, LineSpacer } from 'styles/common';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
 import { Incentives } from 'sections/earn';
 import StatBox from 'components/StatBox';
 
@@ -72,32 +71,30 @@ const Earn = () => {
 			<Head>
 				<title>{t('earn.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<StatsSection>
-					<UpcomingRewards
-						title={t('common.stat-box.upcoming-rewards')}
-						value={formatFiatCurrency(totalRewards, {
-							sign: '$',
-						})}
-					/>
-					<APY
-						title={t('common.stat-box.earning')}
-						value={formatPercent(stakingApy ? stakingApy : 0)}
-						size="lg"
-					/>
-					<LifetimeRewards
-						title={t('common.stat-box.lifetime-rewards')}
-						value={formatFiatCurrency(totalFees ? totalFees : 0, { sign: '$' })}
-					/>
-				</StatsSection>
-				<LineSpacer />
-				<Incentives
-					refetch={refetch}
-					tradingRewards={tradingRewards}
-					stakingRewards={stakingRewards}
-					totalRewards={totalRewards}
+			<StatsSection>
+				<UpcomingRewards
+					title={t('common.stat-box.upcoming-rewards')}
+					value={formatFiatCurrency(totalRewards, {
+						sign: '$',
+					})}
 				/>
-			</AppLayout>
+				<APY
+					title={t('common.stat-box.earning')}
+					value={formatPercent(stakingApy ? stakingApy : 0)}
+					size="lg"
+				/>
+				<LifetimeRewards
+					title={t('common.stat-box.lifetime-rewards')}
+					value={formatFiatCurrency(totalFees ? totalFees : 0, { sign: '$' })}
+				/>
+			</StatsSection>
+			<LineSpacer />
+			<Incentives
+				refetch={refetch}
+				tradingRewards={tradingRewards}
+				stakingRewards={stakingRewards}
+				totalRewards={totalRewards}
+			/>
 		</>
 	);
 };

--- a/pages/escrow.tsx
+++ b/pages/escrow.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import StatBox from 'components/StatBox';
 import { StatsSection, LineSpacer } from 'styles/common';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
 import useEscrowDataQuery from 'queries/escrow/useEscrowDataQuery';
 import { formatCryptoCurrency } from '../utils/formatters/number';
 
@@ -24,31 +23,29 @@ const EscrowPage = () => {
 			<Head>
 				<title>{t('escrow.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<StatsSection>
-					<Available
-						title={t('common.stat-box.available-snx')}
-						value={formatCryptoCurrency(escrowData?.canVest ?? 0, {
-							decimals: SNX_HEADER_DECIMALS,
-						})}
-					/>
-					<Vested
-						title={t('common.stat-box.vested-snx')}
-						value={formatCryptoCurrency(escrowData?.totalVested ?? 0, {
-							decimals: SNX_HEADER_DECIMALS,
-						})}
-						size="lg"
-					/>
-					<Escrowed
-						title={t('common.stat-box.escrowed-snx')}
-						value={formatCryptoCurrency(escrowData?.totalEscrowed ?? 0, {
-							decimals: SNX_HEADER_DECIMALS,
-						})}
-					/>
-				</StatsSection>
-				<LineSpacer />
-				<Main />
-			</AppLayout>
+			<StatsSection>
+				<Available
+					title={t('common.stat-box.available-snx')}
+					value={formatCryptoCurrency(escrowData?.canVest ?? 0, {
+						decimals: SNX_HEADER_DECIMALS,
+					})}
+				/>
+				<Vested
+					title={t('common.stat-box.vested-snx')}
+					value={formatCryptoCurrency(escrowData?.totalVested ?? 0, {
+						decimals: SNX_HEADER_DECIMALS,
+					})}
+					size="lg"
+				/>
+				<Escrowed
+					title={t('common.stat-box.escrowed-snx')}
+					value={formatCryptoCurrency(escrowData?.totalEscrowed ?? 0, {
+						decimals: SNX_HEADER_DECIMALS,
+					})}
+				/>
+			</StatsSection>
+			<LineSpacer />
+			<Main />
 		</>
 	);
 };

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -2,8 +2,6 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
-
 import { StatsSection, LineSpacer } from 'styles/common';
 
 import TransactionsContainer from 'sections/history/TransactionsContainer';
@@ -20,18 +18,16 @@ const HistoryPage = () => {
 			<Head>
 				<title>{t('history.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<StatsSection>
-					<TxCount title={t('common.stat-box.tx-count')} value={txCount} size="lg" />
-				</StatsSection>
-				<LineSpacer />
-				<TransactionsContainer
-					burned={burned}
-					issued={issued}
-					feesClaimed={feesClaimed}
-					isLoaded={isLoaded}
-				/>
-			</AppLayout>
+			<StatsSection>
+				<TxCount title={t('common.stat-box.tx-count')} value={txCount} size="lg" />
+			</StatsSection>
+			<LineSpacer />
+			<TransactionsContainer
+				burned={burned}
+				issued={issued}
+				feesClaimed={feesClaimed}
+				isLoaded={isLoaded}
+			/>
 		</>
 	);
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 
 import { FlexDivCol, LineSpacer, StatsSection } from 'styles/common';
 import { PossibleActions } from 'sections/dashboard';
-import AppLayout from 'sections/shared/Layout/AppLayout';
 
 import useGetDebtDataQuery from 'queries/debt/useGetDebtDataQuery';
 import useGetFeePoolDataQuery from 'queries/staking/useGetFeePoolDataQuery';
@@ -51,27 +50,25 @@ const DashboardPage = () => {
 			<Head>
 				<title>{t('dashboard.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<Content>
-					<StatsSection>
-						<StakedValue
-							title={t('common.stat-box.staked-value')}
-							value={formatFiatCurrency(stakedValue ? stakedValue : 0, { sign: '$' })}
-						/>
-						<APY
-							title={t('common.stat-box.earning')}
-							value={formatPercent(stakingApy ? stakingApy : 0)}
-							size="lg"
-						/>
-						<ActiveDebt
-							title={t('common.stat-box.active-debt')}
-							value={formatFiatCurrency(activeDebt ? activeDebt : 0, { sign: '$' })}
-						/>
-					</StatsSection>
-					<LineSpacer />
-					<PossibleActions />
-				</Content>
-			</AppLayout>
+			<Content>
+				<StatsSection>
+					<StakedValue
+						title={t('common.stat-box.staked-value')}
+						value={formatFiatCurrency(stakedValue ? stakedValue : 0, { sign: '$' })}
+					/>
+					<APY
+						title={t('common.stat-box.earning')}
+						value={formatPercent(stakingApy ? stakingApy : 0)}
+						size="lg"
+					/>
+					<ActiveDebt
+						title={t('common.stat-box.active-debt')}
+						value={formatFiatCurrency(activeDebt ? activeDebt : 0, { sign: '$' })}
+					/>
+				</StatsSection>
+				<LineSpacer />
+				<PossibleActions />
+			</Content>
 		</>
 	);
 };

--- a/pages/staking.tsx
+++ b/pages/staking.tsx
@@ -3,8 +3,6 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
-
 import Main from 'sections/staking';
 import StatBox from 'components/StatBox';
 import { LineSpacer, StatsSection } from 'styles/common';
@@ -26,25 +24,23 @@ const StakingPage = () => {
 			<Head>
 				<title>{t('staking.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<StatsSection>
-					<StakedValue
-						title={t('common.stat-box.staked-value')}
-						value={formatFiatCurrency(stakedCollateralValue, { sign: '$' })}
-					/>
-					<CRatio
-						title={t('common.stat-box.c-ratio')}
-						value={formatPercent(currentCRatio ? 1 / currentCRatio : 0)}
-						size="lg"
-					/>
-					<ActiveDebt
-						title={t('common.stat-box.active-debt')}
-						value={formatFiatCurrency(debtBalance, { sign: '$' })}
-					/>
-				</StatsSection>
-				<LineSpacer />
-				<Main />
-			</AppLayout>
+			<StatsSection>
+				<StakedValue
+					title={t('common.stat-box.staked-value')}
+					value={formatFiatCurrency(stakedCollateralValue, { sign: '$' })}
+				/>
+				<CRatio
+					title={t('common.stat-box.c-ratio')}
+					value={formatPercent(currentCRatio ? 1 / currentCRatio : 0)}
+					size="lg"
+				/>
+				<ActiveDebt
+					title={t('common.stat-box.active-debt')}
+					value={formatFiatCurrency(debtBalance, { sign: '$' })}
+				/>
+			</StatsSection>
+			<LineSpacer />
+			<Main />
 		</>
 	);
 };

--- a/pages/synths.tsx
+++ b/pages/synths.tsx
@@ -2,8 +2,6 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
-
 import { StatsSection, LineSpacer } from 'styles/common';
 
 import { AssetContainer } from 'sections/synths/AssetContainer';
@@ -18,15 +16,13 @@ const SynthsPage = () => {
 			<Head>
 				<title>{t('synths.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<StatsSection>
-					{/* TODO: implement */}
-					<TotalSynthValue title={t('common.stat-box.synth-value')} value="$9,000.08" size="lg" />
-				</StatsSection>
-				<LineSpacer />
-				<AssetContainer title={t('synths.synths.title')} />
-				<AssetContainer title={t('synths.non-synths.title')} />
-			</AppLayout>
+			<StatsSection>
+				{/* TODO: implement */}
+				<TotalSynthValue title={t('common.stat-box.synth-value')} value="$9,000.08" size="lg" />
+			</StatsSection>
+			<LineSpacer />
+			<AssetContainer title={t('synths.synths.title')} />
+			<AssetContainer title={t('synths.non-synths.title')} />
 		</>
 	);
 };


### PR DESCRIPTION
The `LeftNav` used to be very simple, so re-rendering wouldn't be too expensive, but now it has a bunch of logic in it (like chart rendering, etc), so I have moved `<AppLayout>` back to `_app.tsx`. 

`SystemStatus` will still have a standalone layout, so all good.