### PR TITLE
Add c-ratio progress bar to staking page

### DIFF
--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import styled, { css } from 'styled-components';
+import Color from 'color';
 
 import { FlexDivRowCentered } from 'styles/common';
 
@@ -47,13 +48,15 @@ const ProgressBarWrapper = styled(FlexDivRowCentered)<{
 		css`
 			.filled-bar {
 				background: ${(props) => props.theme.colors.blue};
-				border: 1px solid ${(props) => props.theme.colors.blue};
-				box-shadow: 0px 0px 10px rgba(0, 209, 255, 0.6);
+				border: 2px solid ${(props) => props.theme.colors.blue};
+				box-shadow: 0px 0px 15px
+					${(props) => Color(props.theme.colors.blue).alpha(0.6).rgb().string()};
 			}
 
 			.unfilled-bar {
-				border: 1px solid ${(props) => props.theme.colors.pink};
-				box-shadow: 0px 0px 15px ${(props) => props.theme.colors.pink};
+				border: 2px solid ${(props) => props.theme.colors.pink};
+				box-shadow: 0px 0px 15px
+					${(props) => Color(props.theme.colors.pink).alpha(0.6).rgb().string()};
 			}
 		`}
 
@@ -62,13 +65,15 @@ const ProgressBarWrapper = styled(FlexDivRowCentered)<{
 		css`
 			.filled-bar {
 				background: ${(props) => props.theme.colors.green};
-				border: 1px solid ${(props) => props.theme.colors.green};
-				box-shadow: 0px 0px 10px rgba(77, 244, 184, 0.25);
+				border: 2px solid ${(props) => props.theme.colors.green};
+				box-shadow: 0px 0px 15px
+					${(props) => Color(props.theme.colors.green).alpha(0.6).rgb().string()};
 			}
 
 			.unfilled-bar {
-				border: 1px solid ${(props) => props.theme.colors.green};
-				box-shadow: 0px 0px 15px ${(props) => props.theme.colors.green};
+				border: 2px solid ${(props) => props.theme.colors.green};
+				box-shadow: 0px 0px 15px
+					${(props) => Color(props.theme.colors.green).alpha(0.6).rgb().string()};
 			}
 		`}		
 `;

--- a/components/StatBox/StatBox.tsx
+++ b/components/StatBox/StatBox.tsx
@@ -11,12 +11,14 @@ type StatBoxProps = {
 	title: ReactNode;
 	value: ReactNode;
 	size?: Size;
+	children?: ReactNode;
 };
 
-const StatBox: FC<StatBoxProps> = ({ title, value, size = 'md', ...rest }) => (
+const StatBox: FC<StatBoxProps> = ({ title, value, size = 'md', children, ...rest }) => (
 	<Box {...rest} size={size}>
 		<Title className="title">{title}</Title>
 		<Value className="value">{value}</Value>
+		{children}
 	</Box>
 );
 

--- a/pages/staking/[[...action]].tsx
+++ b/pages/staking/[[...action]].tsx
@@ -11,10 +11,16 @@ import useStakingCalculations from 'sections/staking/hooks/useStakingCalculation
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { useRecoilValue } from 'recoil';
 import { isWalletConnectedState } from 'store/wallet';
+import ProgressBar from 'components/ProgressBar';
 
 const StakingPage = () => {
 	const { t } = useTranslation();
-	const { stakedCollateralValue, percentageCurrentCRatio, debtBalance } = useStakingCalculations();
+	const {
+		stakedCollateralValue,
+		percentageCurrentCRatio,
+		debtBalance,
+		percentCurrentCRatioOfTarget,
+	} = useStakingCalculations();
 	const { selectedPriceCurrency, getPriceAtCurrentRate } = useSelectedPriceCurrency();
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 
@@ -39,7 +45,14 @@ const StakingPage = () => {
 					title={t('common.stat-box.c-ratio')}
 					value={isWalletConnected ? formatPercent(percentageCurrentCRatio) : '-%'}
 					size="lg"
-				/>
+				>
+					<CRatioProgressBar
+						variant="blue-pink"
+						percentage={
+							percentCurrentCRatioOfTarget.isNaN() ? 0 : percentCurrentCRatioOfTarget.toNumber()
+						}
+					/>
+				</CRatio>
 				<ActiveDebt
 					title={t('common.stat-box.active-debt')}
 					value={formatFiatCurrency(
@@ -71,6 +84,14 @@ const ActiveDebt = styled(StatBox)`
 	.title {
 		color: ${(props) => props.theme.colors.pink};
 	}
+`;
+
+export const CRatioProgressBar = styled(ProgressBar)`
+	height: 6px;
+	width: 100%;
+	transform: translateY(12px);
+	// match StatBox "lg" background size width
+	max-width: 176px;
 `;
 
 export default StakingPage;

--- a/pages/staking/[[...action]].tsx
+++ b/pages/staking/[[...action]].tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import Main from 'sections/staking';
-import StatBox from 'components/StatBox';
 import { LineSpacer, StatsSection } from 'styles/common';
+
 import { formatFiatCurrency, formatPercent, toBigNumber } from 'utils/formatters/number';
+
+import Main from 'sections/staking';
 import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
+
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import { useRecoilValue } from 'recoil';
+
 import { isWalletConnectedState } from 'store/wallet';
+
+import StatBox from 'components/StatBox';
 import ProgressBar from 'components/ProgressBar';
 
 const StakingPage = () => {


### PR DESCRIPTION
<img width="286" alt="Screen Shot 2021-01-04 at 10 15 11 pm" src="https://user-images.githubusercontent.com/254095/103529812-6fc5c080-4eda-11eb-98ec-7d617e77e6d8.png">

Also updated the progress bar's to use the correct border width and some box-shadow fixes.