### PR TITLE
Add Lattice1 Hardware Support & Bump Blocknative Onboard to v.1.18.0

### DIFF
--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -26,6 +26,11 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 					preferred: true,
 				},
 				{
+					walletName: 'lattice',
+					appName: 'Synthetix',
+					rpcUrl: infuraRpc,
+				},
+				{
 					walletName: 'trezor',
 					appUrl: 'https://www.synthetix.io',
 					email: 'info@synthetix.io',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,68 +1656,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@chainlink/contracts-0.0.10": {
-      "version": "npm:@chainlink/contracts@0.0.10",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
-      "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
-      "requires": {
-        "@truffle/contract": "^4.2.6",
-        "ethers": "^4.0.45"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-          "optional": true
-        },
-        "ethers": {
-          "version": "4.0.48",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
-          "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
-          "optional": true,
-          "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.5.3",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "optional": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-          "optional": true
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "optional": true
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "optional": true
-        }
-      }
-    },
     "@chaitanyapotti/random-id": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@chaitanyapotti/random-id/-/random-id-1.0.3.tgz",
@@ -2560,21 +2498,22 @@
       }
     },
     "@ledgerhq/cryptoassets": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/cryptoassets/-/cryptoassets-5.28.0.tgz",
-      "integrity": "sha512-jf7saGFCBzf+4TKoI4wiBztC9K1N6mjFsuSe8S5op7pjJMEjWXUZL1o7yXP6GiYiMyBIOknQAb/kbN32rPhTJQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/cryptoassets/-/cryptoassets-5.39.0.tgz",
+      "integrity": "sha512-pg3SAqUO66aumTZaorb4YkvjS5m123tRnSO4j/gmT3YzDtGwKI1pWjDOXQzsPL7xvaaUHyiotZFlnf3p60QQkg==",
       "requires": {
         "invariant": "2"
       }
     },
     "@ledgerhq/devices": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.28.0.tgz",
-      "integrity": "sha512-Tkygc1nfioxfv4YWF5VGHito3ZHQAiNM7YV+Kqr3n/gz4meT5f9DfvqvikTF5XxX+mXpCMc4IlzwbUAoeNOHiQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.39.0.tgz",
+      "integrity": "sha512-lMkVRdDUy9B054GdwChAT9Av7OXCuORA9pD+xG3Nucl+KSUUevX52SL2KGE5y4lAQEzcPbNNOM7H341iOfaaEA==",
       "requires": {
-        "@ledgerhq/errors": "^5.28.0",
-        "@ledgerhq/logs": "^5.28.0",
-        "rxjs": "^6.6.3"
+        "@ledgerhq/errors": "^5.39.0",
+        "@ledgerhq/logs": "^5.39.0",
+        "rxjs": "^6.6.3",
+        "semver": "^7.3.4"
       },
       "dependencies": {
         "rxjs": {
@@ -2584,22 +2523,30 @@
           "requires": {
             "tslib": "^1.9.0"
           }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
     "@ledgerhq/errors": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.28.0.tgz",
-      "integrity": "sha512-dNBVriJbdiTerT7I102sAMBxuJqmuMCQSfIdQ+3euvb+2Fx7UPM/w9RHZ0HZGsz/SdeBblWAH0aIQmtDX/vW9g=="
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.39.0.tgz",
+      "integrity": "sha512-N4/0NO2qgRlF+6QG9a4kGurmi2p6rcYyWeJb4QxU8ypGqBgzMBYjx0LM68JfGFAN5niAuqHZtDZ87EPSrXyu6Q=="
     },
     "@ledgerhq/hw-app-eth": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.28.0.tgz",
-      "integrity": "sha512-XIQPydYryxbW743NNf8pJ7MI5uu0TjynrLjdoz6glnRxM5q3yStRvLdej4ievwr4d8tH8431gdagXtz0ewFOuA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.39.0.tgz",
+      "integrity": "sha512-YDN85sinZVc89VXlxl6YjtsQ/jbxZCZhiTifO0rr8PCTbVhSDtQQMLk9FEn9ZXeShcAV+1D4pUl33WA5bAZC6Q==",
       "requires": {
-        "@ledgerhq/cryptoassets": "^5.28.0",
-        "@ledgerhq/errors": "^5.28.0",
-        "@ledgerhq/hw-transport": "^5.28.0",
+        "@ledgerhq/cryptoassets": "^5.39.0",
+        "@ledgerhq/errors": "^5.39.0",
+        "@ledgerhq/hw-transport": "^5.39.0",
         "bignumber.js": "^9.0.1",
         "rlp": "^2.2.6"
       },
@@ -2612,30 +2559,35 @@
       }
     },
     "@ledgerhq/hw-transport": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.28.0.tgz",
-      "integrity": "sha512-dQm45axzWSJhiaDB2csBCFPH/PGjE8kB+3uSeoUJ752FqgndZgrN9UKOPPxcmaf69jnQeTZAFEWc8g63yMPYOg==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.39.0.tgz",
+      "integrity": "sha512-yqW83K7wlF2hju7Ur1Ss6y+I9w41S8VM8Li+Y4N9WMbEPKEJ+7+utaK0dnsv1yVsCSFitC9cHNZedxgCQTW4bQ==",
       "requires": {
-        "@ledgerhq/devices": "^5.28.0",
-        "@ledgerhq/errors": "^5.28.0",
+        "@ledgerhq/devices": "^5.39.0",
+        "@ledgerhq/errors": "^5.39.0",
         "events": "^3.2.0"
       }
     },
     "@ledgerhq/hw-transport-u2f": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.28.0.tgz",
-      "integrity": "sha512-p/4CB+Sf5c1pLUjVWnHCm6Ll6atratfWlgFSmqt8yRxxejB5mwlK+4HkX8Tq4wgooZe2PqDuVTdFxGwiq4nAeg==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.34.0.tgz",
+      "integrity": "sha512-EM6LcbdD6Xo/msedbAWalBZlv89XAZrAZwL5zN9eKlUcWPjjG8c9+t5NedR/jmIaGuzIUVseUCIRxczqd5byOw==",
       "requires": {
-        "@ledgerhq/errors": "^5.28.0",
-        "@ledgerhq/hw-transport": "^5.28.0",
-        "@ledgerhq/logs": "^5.28.0",
+        "@ledgerhq/errors": "^5.34.0",
+        "@ledgerhq/hw-transport": "^5.34.0",
+        "@ledgerhq/logs": "^5.30.0",
         "u2f-api": "0.2.7"
       }
     },
     "@ledgerhq/logs": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.28.0.tgz",
-      "integrity": "sha512-O+p30yQCJVMHkYRt4mEy2My61JNTyqg9FEs9ZmXXPvXbod85snD6oGaKtDtcvbWCYjiaQt4alD+w/J56hkNBWQ=="
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.39.0.tgz",
+      "integrity": "sha512-kkVtWPCss5DiizQeVMMWHhlDnF9Lft8nbIUpJsRXgiCYh4Avjsx6wYS0fiZRpRla6ki67aXRJWSnKCohH0F3BA=="
+    },
+    "@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
     },
     "@microsoft/eslint-formatter-sarif": {
       "version": "2.1.5",
@@ -2644,7 +2596,7 @@
       "dev": true,
       "requires": {
         "chai": "^4.2.0",
-        "jschardet": "2.2.1",
+        "jschardet": "^2.2.1",
         "lodash": "^4.17.14",
         "mocha": "^5.2.0",
         "utf8": "^3.0.0"
@@ -2923,11 +2875,6 @@
         }
       }
     },
-    "@restless/sanitizers": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@restless/sanitizers/-/sanitizers-0.2.5.tgz",
-      "integrity": "sha512-utsOFwv5owNnbj8HijF7uML/AURgUl5YvY4S2gpxQsrp2D1EP/4rQU/HSyYdIQaL89BoZ/5NHveRJrcFyuHo/w=="
-    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -3071,6 +3018,34 @@
         "web3-utils": "1.2.11"
       },
       "dependencies": {
+        "@chainlink/contracts-0.0.10": {
+          "version": "npm:@chainlink/contracts@0.0.10",
+          "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+          "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+          "requires": {
+            "@truffle/contract": "^4.2.6",
+            "ethers": "^4.0.45"
+          },
+          "dependencies": {
+            "ethers": {
+              "version": "4.0.48",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+              "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+              "optional": true,
+              "requires": {
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.5.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.4",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            }
+          }
+        },
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -3112,10 +3087,37 @@
             "@ethersproject/wordlists": "^5.0.0"
           }
         },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.19",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
           "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+        },
+        "openzeppelin-solidity-2.3.0": {
+          "version": "npm:openzeppelin-solidity@2.3.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "optional": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "optional": true
         },
         "synthetix": {
           "version": "2.37.0",
@@ -3149,6 +3151,12 @@
               }
             }
           }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "optional": true
         }
       }
     },
@@ -3859,34 +3867,211 @@
       }
     },
     "@toruslabs/fetch-node-details": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@toruslabs/fetch-node-details/-/fetch-node-details-2.3.1.tgz",
-      "integrity": "sha512-Q7ONMxQ9fjpzkdEm5iVQAWTIr7wFK9Po2c9WW9qpEzhqhY9/WYThcmH73pvjfQtkzZ2oXq4rjKwDOW0Fdb1Xmw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@toruslabs/fetch-node-details/-/fetch-node-details-2.3.4.tgz",
+      "integrity": "sha512-k09DHUR29Cjm/gJHV3ADg1R3Jr4t0oB1PugRiFY3vV69XL2D1TDw15Ntc34bjvGuSAFoFacuPw+fG+eO0ZQQrg==",
       "requires": {
-        "web3-eth-contract": "^1.3.0",
-        "web3-utils": "^1.3.0"
+        "web3-eth-contract": "^1.3.1",
+        "web3-utils": "^1.3.1"
       },
       "dependencies": {
         "@ethersproject/abi": {
-          "version": "5.0.0-beta.153",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
-          "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+          "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
           "requires": {
-            "@ethersproject/address": ">=5.0.0-beta.128",
-            "@ethersproject/bignumber": ">=5.0.0-beta.130",
-            "@ethersproject/bytes": ">=5.0.0-beta.129",
-            "@ethersproject/constants": ">=5.0.0-beta.128",
-            "@ethersproject/hash": ">=5.0.0-beta.128",
-            "@ethersproject/keccak256": ">=5.0.0-beta.127",
-            "@ethersproject/logger": ">=5.0.0-beta.129",
-            "@ethersproject/properties": ">=5.0.0-beta.131",
-            "@ethersproject/strings": ">=5.0.0-beta.130"
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
+          "integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/networks": "^5.0.7",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/transactions": "^5.0.9",
+            "@ethersproject/web": "^5.0.12"
+          },
+          "dependencies": {
+            "@ethersproject/transactions": {
+              "version": "5.0.9",
+              "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
+              "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
+              "requires": {
+                "@ethersproject/address": "^5.0.9",
+                "@ethersproject/bignumber": "^5.0.13",
+                "@ethersproject/bytes": "^5.0.9",
+                "@ethersproject/constants": "^5.0.8",
+                "@ethersproject/keccak256": "^5.0.7",
+                "@ethersproject/logger": "^5.0.8",
+                "@ethersproject/properties": "^5.0.7",
+                "@ethersproject/rlp": "^5.0.7",
+                "@ethersproject/signing-key": "^5.0.8"
+              }
+            }
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
+          "integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.8",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
+          "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
+          "integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.13",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
+          "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
+          "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
+          "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
+          "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.10",
+            "@ethersproject/address": "^5.0.9",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
+          "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
+          "integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
+          "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
+          "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
+          "integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "elliptic": "6.5.3"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
+          "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
+          "integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
+          "requires": {
+            "@ethersproject/base64": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8"
           }
         },
         "@types/node": {
-          "version": "12.19.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.3.tgz",
-          "integrity": "sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg=="
+          "version": "12.19.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.14.tgz",
+          "integrity": "sha512-2U9uLN46+7dv9PiS8VQJcHhuoOjiDPZOLAt0WuA1EanEknIMae+2QbMhayF7cgGqjvRVIfNpt+6jLPczJZFiRw=="
         },
         "bn.js": {
           "version": "4.11.9",
@@ -3916,142 +4101,156 @@
             "http-https": "^1.0.0"
           }
         },
+        "util": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+          "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
         "web3-core": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.0.tgz",
-          "integrity": "sha512-BwWvAaKJf4KFG9QsKRi3MNoNgzjI6szyUlgme1qNPxUdCkaS3Rdpa0VKYNHP7M/YTk82/59kNE66mH5vmoaXjA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.1.tgz",
+          "integrity": "sha512-QlBwSyjl2pqYUBE7lH9PfLxa8j6AzzAtvLUqkgoaaFJYLP/+XavW1n6dhVCTq+U3L3eNc+bMp9GLjGDJNXMnGg==",
           "requires": {
             "@types/bn.js": "^4.11.5",
             "@types/node": "^12.12.6",
             "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.3.0",
-            "web3-core-method": "1.3.0",
-            "web3-core-requestmanager": "1.3.0",
-            "web3-utils": "1.3.0"
+            "web3-core-helpers": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-core-requestmanager": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-core-helpers": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.0.tgz",
-          "integrity": "sha512-+MFb1kZCrRctf7UYE7NCG4rGhSXaQJ/KF07di9GVK1pxy1K0+rFi61ZobuV1ky9uQp+uhhSPts4Zp55kRDB5sw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.1.tgz",
+          "integrity": "sha512-tMVU0ScyQUJd/HFWfZrvGf+QmPCodPyKQw1gQ+n9We/H3vPPbUxDjNeYnd4BbYy5O9ox+0XG6i3+JlwiSkgDkA==",
           "requires": {
             "underscore": "1.9.1",
-            "web3-eth-iban": "1.3.0",
-            "web3-utils": "1.3.0"
+            "web3-eth-iban": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-core-method": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.0.tgz",
-          "integrity": "sha512-h0yFDrYVzy5WkLxC/C3q+hiMnzxdWm9p1T1rslnuHgOp6nYfqzu/6mUIXrsS4h/OWiGJt+BZ0xVZmtC31HDWtg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.1.tgz",
+          "integrity": "sha512-dA38tNVZWTxBFMlLFunLD5Az1AWRi5HqM+AtQrTIhxWCzg7rJSHuaYOZ6A5MHKGPWpdykLhzlna0SsNv5AVs8w==",
           "requires": {
             "@ethersproject/transactions": "^5.0.0-beta.135",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.0",
-            "web3-core-promievent": "1.3.0",
-            "web3-core-subscriptions": "1.3.0",
-            "web3-utils": "1.3.0"
+            "web3-core-helpers": "1.3.1",
+            "web3-core-promievent": "1.3.1",
+            "web3-core-subscriptions": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-core-promievent": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.0.tgz",
-          "integrity": "sha512-blv69wrXw447TP3iPvYJpllkhW6B18nfuEbrfcr3n2Y0v1Jx8VJacNZFDFsFIcgXcgUIVCtOpimU7w9v4+rtaw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.1.tgz",
+          "integrity": "sha512-jGu7TkwUqIHlvWd72AlIRpsJqdHBQnHMeMktrows2148gg5PBPgpJ10cPFmCCzKT6lDOVh9B7pZMf9eckMDmiA==",
           "requires": {
             "eventemitter3": "4.0.4"
           }
         },
         "web3-core-requestmanager": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.0.tgz",
-          "integrity": "sha512-3yMbuGcomtzlmvTVqNRydxsx7oPlw3ioRL6ReF9PeNYDkUsZaUib+6Dp5eBt7UXh5X+SIn/xa1smhDHz5/HpAw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.1.tgz",
+          "integrity": "sha512-9WTaN2SoyJX1amRyTzX2FtbVXsyWBI2Wef2Q3gPiWaEo/VRVm3e4Bq8MwxNTUMIJMO8RLGHjtdgsoDKPwfL73Q==",
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.0",
-            "web3-providers-http": "1.3.0",
-            "web3-providers-ipc": "1.3.0",
-            "web3-providers-ws": "1.3.0"
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.3.1",
+            "web3-providers-http": "1.3.1",
+            "web3-providers-ipc": "1.3.1",
+            "web3-providers-ws": "1.3.1"
           }
         },
         "web3-core-subscriptions": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.0.tgz",
-          "integrity": "sha512-MUUQUAhJDb+Nz3S97ExVWveH4utoUnsbPWP+q1HJH437hEGb4vunIb9KvN3hFHLB+aHJfPeStM/4yYTz5PeuyQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.1.tgz",
+          "integrity": "sha512-eX3N5diKmrxshc6ZBZ8EJxxAhCxdYPbYXuF2EfgdIyHmxwmYqIVvKepzO8388Bx8JD3D0Id/pKE0dC/FnDIHTQ==",
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.0"
+            "web3-core-helpers": "1.3.1"
           }
         },
         "web3-eth-abi": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.0.tgz",
-          "integrity": "sha512-1OrZ9+KGrBeBRd3lO8upkpNua9+7cBsQAgor9wbA25UrcUYSyL8teV66JNRu9gFxaTbkpdrGqM7J/LXpraXWrg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.1.tgz",
+          "integrity": "sha512-ds4aTeKDUEqTXgncAtxvcfMpPiei9ey7+s2ZZ+OazK2CK5jWhFiJuuj9Q68kOT+hID7E1oSDVsNmJWFD/7lbMw==",
           "requires": {
-            "@ethersproject/abi": "5.0.0-beta.153",
+            "@ethersproject/abi": "5.0.7",
             "underscore": "1.9.1",
-            "web3-utils": "1.3.0"
+            "web3-utils": "1.3.1"
           }
         },
         "web3-eth-contract": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.0.tgz",
-          "integrity": "sha512-3SCge4SRNCnzLxf0R+sXk6vyTOl05g80Z5+9/B5pERwtPpPWaQGw8w01vqYqsYBKC7zH+dxhMaUgVzU2Dgf7bQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.1.tgz",
+          "integrity": "sha512-cHu9X1iGrK+Zbrj4wYKwHI1BtVGn/9O0JRsZqd9qcFGLwwAmaCJYy0sDn7PKCKDSL3qB+MDILoyI7FaDTWWTHg==",
           "requires": {
             "@types/bn.js": "^4.11.5",
             "underscore": "1.9.1",
-            "web3-core": "1.3.0",
-            "web3-core-helpers": "1.3.0",
-            "web3-core-method": "1.3.0",
-            "web3-core-promievent": "1.3.0",
-            "web3-core-subscriptions": "1.3.0",
-            "web3-eth-abi": "1.3.0",
-            "web3-utils": "1.3.0"
+            "web3-core": "1.3.1",
+            "web3-core-helpers": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-core-promievent": "1.3.1",
+            "web3-core-subscriptions": "1.3.1",
+            "web3-eth-abi": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-eth-iban": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.0.tgz",
-          "integrity": "sha512-v9mZWhR4fPF17/KhHLiWir4YHWLe09O3B/NTdhWqw3fdAMJNztzMHGzgHxA/4fU+rhrs/FhDzc4yt32zMEXBZw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.1.tgz",
+          "integrity": "sha512-RCQLfR9Z+DNfpw7oUauYHg1HcVoEljzhwxKn3vi15gK0ssWnTwRGqUiIyVTeSb836G6oakOd5zh7XYqy7pn+nw==",
           "requires": {
             "bn.js": "^4.11.9",
-            "web3-utils": "1.3.0"
+            "web3-utils": "1.3.1"
           }
         },
         "web3-providers-http": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.0.tgz",
-          "integrity": "sha512-cMKhUI6PqlY/EC+ZDacAxajySBu8AzW8jOjt1Pe/mbRQgS0rcZyvLePGTTuoyaA8C21F8UW+EE5jj7YsNgOuqA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.1.tgz",
+          "integrity": "sha512-DOujG6Ts7/hAMj0PW5p9/1vwxAIr+1CJ6ZWHshtfOq1v1KnMphVTGOrjcTTUvPT33/DA/so2pgGoPMrgaEIIvQ==",
           "requires": {
-            "web3-core-helpers": "1.3.0",
+            "web3-core-helpers": "1.3.1",
             "xhr2-cookies": "1.1.0"
           }
         },
         "web3-providers-ipc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.0.tgz",
-          "integrity": "sha512-0CrLuRofR+1J38nEj4WsId/oolwQEM6Yl1sOt41S/6bNI7htdkwgVhSloFIMJMDFHtRw229QIJ6wIaKQz0X1Og==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.1.tgz",
+          "integrity": "sha512-BNPscLbvwo+u/tYJrLvPnl/g/SQVSnqP/TjEsB033n4IXqTC4iZ9Of8EDmI0U6ds/9nwNqOBx3KsxbinL46UZA==",
           "requires": {
             "oboe": "2.1.5",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.0"
+            "web3-core-helpers": "1.3.1"
           }
         },
         "web3-providers-ws": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.0.tgz",
-          "integrity": "sha512-Im5MthhJnJst8nSoq0TgbyOdaiFQFa5r6sHPOVllhgIgViDqzbnlAFW9sNzQ0Q8VXPNfPIQKi9cOrHlSRNPjRw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.1.tgz",
+          "integrity": "sha512-DAbVbiizv0Hr/bLKjyyKMHc/66ccVkudan3eRsf+R/PXWCqfXb7q6Lwodj4llvC047pEuLKR521ZKr5wbfk1KQ==",
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.0",
+            "web3-core-helpers": "1.3.1",
             "websocket": "^1.0.32"
           }
         },
         "web3-utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
-          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.1.tgz",
+          "integrity": "sha512-9gPwFm8SXtIJuzdrZ37PRlalu40fufXxo+H2PiCwaO6RpKGAvlUlWU0qQbyToFNXg7W2H8djEgoAVac8NLMCKQ==",
           "requires": {
             "bn.js": "^4.11.9",
             "eth-lib": "0.2.8",
@@ -4074,71 +4273,66 @@
       }
     },
     "@toruslabs/torus-embed": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@toruslabs/torus-embed/-/torus-embed-1.8.6.tgz",
-      "integrity": "sha512-7u23gH783weAqAJMTBS9unDsBhL/n6KKkRbTVNCRF9lAqMNznxj+yYWGaVxJkmL5x6gl3P5jbLgji8/KoV0I1w==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus-embed/-/torus-embed-1.9.6.tgz",
+      "integrity": "sha512-9wD77wFsYKv0su3alGw+YzDbRx/T8H2sQahLN/ygV/eyXWBBAOBHDI1JAGAoOSFXC1R9Wma2sLU5fPwmM/3Q6w==",
       "requires": {
         "@chaitanyapotti/random-id": "^1.0.3",
-        "@toruslabs/fetch-node-details": "^2.3.0",
-        "@toruslabs/http-helpers": "^1.3.4",
-        "@toruslabs/torus.js": "^2.2.5",
+        "@toruslabs/fetch-node-details": "^2.3.4",
+        "@toruslabs/http-helpers": "^1.3.5",
+        "@toruslabs/torus.js": "^2.2.13",
         "create-hash": "^1.2.0",
         "deepmerge": "^4.2.2",
-        "eth-json-rpc-errors": "^2.0.2",
+        "eth-rpc-errors": "^4.0.2",
         "fast-deep-equal": "^3.1.3",
         "is-stream": "^2.0.0",
-        "json-rpc-engine": "^5.1.8",
-        "json-rpc-middleware-stream": "^2.1.1",
-        "loglevel": "^1.6.8",
+        "json-rpc-engine": "^6.1.0",
+        "json-rpc-middleware-stream": "^3.0.0",
+        "loglevel": "^1.7.1",
         "obj-multiplex": "^1.0.0",
         "obs-store": "^4.0.3",
         "post-message-stream": "^3.0.0",
         "pump": "^3.0.0",
-        "safe-event-emitter": "^1.0.1",
-        "web3": "^0.20.7"
+        "safe-event-emitter": "^1.0.1"
       },
       "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+        "eth-rpc-errors": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.2.tgz",
+          "integrity": "sha512-n+Re6Gu8XGyfFy1it0AwbD1x0MUzspQs0D5UiPs1fFPCr6WAwZM+vbIhXheBFrpgosqN9bs5PqlB4Q61U/QytQ==",
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
         },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
-        "utf8": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
-        },
-        "web3": {
-          "version": "0.20.7",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
-          "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
+        "json-rpc-engine": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+          "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2-cookies": "^1.1.0",
-            "xmlhttprequest": "*"
+            "@metamask/safe-event-emitter": "^2.0.0",
+            "eth-rpc-errors": "^4.0.2"
           }
         }
       }
     },
     "@toruslabs/torus.js": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-2.2.6.tgz",
-      "integrity": "sha512-DxCqaN0Vc69nMMfeQTvqs0Pei5zYaC6yQcnsKtiVwCgm5pmK75wgcvoM4qAfdtmj1fkek5ux+CswQ2DRp+b0tg==",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-2.2.14.tgz",
+      "integrity": "sha512-cB6xV4PHIgXcatNYV7UGELd0pPLk4oApTNui3UTUWcYjv4EPFfgG7YO/DOJYUX7PhXDDJdMgJ2tlEkgqh0n8PA==",
       "requires": {
         "@toruslabs/eccrypto": "^1.1.5",
         "@toruslabs/http-helpers": "^1.3.5",
         "bn.js": "^5.1.3",
         "elliptic": "^6.5.3",
         "json-stable-stringify": "^1.0.1",
-        "loglevel": "^1.7.0",
+        "loglevel": "^1.7.1",
         "memory-cache": "^0.2.0",
-        "web3-utils": "^1.3.0"
+        "web3-utils": "^1.3.1"
       },
       "dependencies": {
         "eth-lib": {
@@ -4159,9 +4353,9 @@
           }
         },
         "web3-utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
-          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.1.tgz",
+          "integrity": "sha512-9gPwFm8SXtIJuzdrZ37PRlalu40fufXxo+H2PiCwaO6RpKGAvlUlWU0qQbyToFNXg7W2H8djEgoAVac8NLMCKQ==",
           "requires": {
             "bn.js": "^4.11.9",
             "eth-lib": "0.2.8",
@@ -4980,15 +5174,6 @@
         }
       }
     },
-    "@unilogin/provider": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@unilogin/provider/-/provider-0.6.1.tgz",
-      "integrity": "sha512-S96uBfoh+/nk8L6Yr+YgEV+FwQgtRnozWhgJpOhmRz128ri5Qv2SXLx5Sac33NGbs8g27PgKOyHX3dKJCvcP3g==",
-      "requires": {
-        "@restless/sanitizers": "^0.2.5",
-        "reactive-properties": "^0.1.11"
-      }
-    },
     "@walletconnect/client": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.3.1.tgz",
@@ -5616,6 +5801,11 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -5817,9 +6007,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "authereum": {
-      "version": "0.0.4-beta.201",
-      "resolved": "https://registry.npmjs.org/authereum/-/authereum-0.0.4-beta.201.tgz",
-      "integrity": "sha512-9zyS2nDsO5nW/8dD8SbGUbZLX76O5Zrx6Zq4aZG+Waa3Vsn3Bj82tn8HLPdECmd5heSOmaSEi5TNsS/sGBSiGw==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/authereum/-/authereum-0.1.13.tgz",
+      "integrity": "sha512-qLngTf4Ixas4b7BT6EunkAdxVdeCG2u6tf8kEjFjtEJSUT1etuTUPK8hb+nO0EqRJWhZkwB5V2GJSR/f1IYnnQ==",
       "requires": {
         "async": "3.2.0",
         "bn.js": "5.1.2",
@@ -6089,6 +6279,14 @@
             "async-limiter": "~1.0.0"
           }
         }
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
       }
     },
     "await-semaphore": {
@@ -7625,6 +7823,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "bitwise": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/bitwise/-/bitwise-2.0.4.tgz",
+      "integrity": "sha512-ZOByl1Sc8SH2/owfRfR1apaC1ELNqHqAAtfqs1Ixqk/9Bod6VxWz10MiMYXkNiL95RdFAqOGQxm1TCGPf1iFyw=="
+    },
     "bl": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -7669,27 +7872,25 @@
       }
     },
     "bnc-onboard": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/bnc-onboard/-/bnc-onboard-1.14.0.tgz",
-      "integrity": "sha512-++wK33BMWLvogo+k4BaHOn25LC7RBT0qsECQh8llv1jHd8r53OKF19PzanZ1J9MH+tB7EQkb8/mInbGKJSlU3w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/bnc-onboard/-/bnc-onboard-1.18.0.tgz",
+      "integrity": "sha512-l2ruQT6Tvl0s/qU+IA6W/h+H6rgfuDCleGnxq6ZlR59pV0DR8v1QYkGzX21J6nTZapYaU+TIiqnCYGuNlVLSEA==",
       "requires": {
         "@ledgerhq/hw-app-eth": "^5.21.0",
         "@ledgerhq/hw-transport-u2f": "^5.21.0",
         "@portis/web3": "^2.0.0-beta.57",
-        "@toruslabs/torus-embed": "^1.8.2",
-        "@unilogin/provider": "^0.6.1",
-        "@walletconnect/web3-provider": "^1.1.0",
-        "authereum": "^0.0.4-beta.157",
+        "@toruslabs/torus-embed": "^1.9.2",
+        "@walletconnect/web3-provider": "^1.3.1",
+        "authereum": "^0.1.12",
         "bignumber.js": "^9.0.0",
         "bnc-sdk": "^2.1.4",
         "bowser": "^2.10.0",
-        "eth-lattice-keyring": "^0.2.4",
+        "eth-lattice-keyring": "^0.2.7",
         "ethereumjs-tx": "^2.1.2",
         "ethereumjs-util": "^7.0.3",
         "fortmatic": "^2.2.1",
         "hdkey": "^2.0.1",
         "regenerator-runtime": "^0.13.7",
-        "squarelink": "^1.1.4",
         "trezor-connect": "^8.1.9",
         "walletlink": "^2.0.2",
         "web3-provider-engine": "^15.0.4"
@@ -8028,9 +8229,9 @@
       "dev": true
     },
     "bufferutil": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
-      "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -9187,7 +9388,8 @@
     "crypto-js": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==",
+      "optional": true
     },
     "css": {
       "version": "2.2.4",
@@ -11786,11 +11988,11 @@
       }
     },
     "eth-lattice-keyring": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/eth-lattice-keyring/-/eth-lattice-keyring-0.2.6.tgz",
-      "integrity": "sha512-SAwjjGIebLF3EXv4hvTyT14oRg3Qe7hFtHz3gZNz+qRhhkH/ilAG8/DmgXXrJchIdR0l+WpSDxejmXbSnkpa2A==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lattice-keyring/-/eth-lattice-keyring-0.2.8.tgz",
+      "integrity": "sha512-dgx1DfdutxVt7Vb/tyFq/U+e0GmXejctfhjyK2HVQHagPfTJj4gbWAMPXyGPPOcxQ4fPdfgr6PlWNTiy96fEKQ==",
       "requires": {
-        "gridplus-sdk": "0.6.1"
+        "gridplus-sdk": "^0.7.2"
       }
     },
     "eth-lib": {
@@ -13135,6 +13337,11 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -13626,11 +13833,13 @@
       }
     },
     "gridplus-sdk": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/gridplus-sdk/-/gridplus-sdk-0.6.1.tgz",
-      "integrity": "sha512-J7Lul1u5qx3I/9Ic+3RnBODE2GtaSHJGtwyZ9GHoVabUtxJoWraX6kz67mGzrGo3ewKn6MX6ThH1QOhOa8acWA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/gridplus-sdk/-/gridplus-sdk-0.7.2.tgz",
+      "integrity": "sha512-fCo9QGvpwTVbqobKmkkKQxRA/zgSy5KOfQrRv9jhnmlP4uHvURKuuqnJ07mRZr+0EbGifRJp9VRmZkKjKffp+Q==",
       "requires": {
         "aes-js": "^3.1.1",
+        "bignumber.js": "^9.0.1",
+        "bitwise": "^2.0.4",
         "bs58": "^4.0.1",
         "bs58check": "^2.1.2",
         "buffer": "^5.6.0",
@@ -13648,18 +13857,15 @@
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
           "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
         },
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
         "js-sha3": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-        },
-        "rlp-browser": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/rlp-browser/-/rlp-browser-1.0.1.tgz",
-          "integrity": "sha512-JU+9ntlfyKanOOPwtNuMZBmCQ/fWVoryfa7ZSYDTUKAa1zk4v2smvM0WV8BsskJuqn/DdxpO7HO2vEikMvmhOA==",
-          "requires": {
-            "buffer": "^5.4.2"
-          }
         }
       }
     },
@@ -14526,6 +14732,11 @@
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
       "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
+    "is-generator-function": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
+      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ=="
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -14674,6 +14885,114 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
         "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
+      "integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+          "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+        },
+        "is-negative-zero": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+          "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+          "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+          "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "is-typedarray": {
@@ -14826,12 +15145,12 @@
       }
     },
     "json-rpc-middleware-stream": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-2.1.1.tgz",
-      "integrity": "sha512-WZheufPN+/RKkjXQP3lK5tFYblqG0n+oYv5qpammwwY2vsJRB7mM4Txhr4ajzvYEZi1UkENnplrmaYiqaqafaA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-3.0.0.tgz",
+      "integrity": "sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==",
       "requires": {
-        "readable-stream": "^2.3.3",
-        "safe-event-emitter": "^1.0.1"
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "readable-stream": "^2.3.3"
       }
     },
     "json-rpc-random-id": {
@@ -15980,9 +16299,9 @@
       }
     },
     "loglevel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
-      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
     },
     "longest": {
       "version": "1.0.1",
@@ -17647,11 +17966,6 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
       "dev": true
     },
-    "openzeppelin-solidity-2.3.0": {
-      "version": "npm:openzeppelin-solidity@2.3.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-      "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
-    },
     "optimized-images-loader": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/optimized-images-loader/-/optimized-images-loader-0.4.0.tgz",
@@ -19013,11 +19327,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "reactive-properties": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/reactive-properties/-/reactive-properties-0.1.12.tgz",
-      "integrity": "sha512-jPpTyoAZOvMhq3pt87X/kZ1zT4j1aad8iafSRHOziYfhBYVYTiUjmIYAxZPmcFziF/4JbEsA7DXA91ZzdosQyQ=="
-    },
     "read-file-async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-file-async/-/read-file-async-1.0.0.tgz",
@@ -19654,6 +19963,14 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
+      }
+    },
+    "rlp-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rlp-browser/-/rlp-browser-1.0.1.tgz",
+      "integrity": "sha512-JU+9ntlfyKanOOPwtNuMZBmCQ/fWVoryfa7ZSYDTUKAa1zk4v2smvM0WV8BsskJuqn/DdxpO7HO2vEikMvmhOA==",
+      "requires": {
+        "buffer": "^5.4.2"
       }
     },
     "rpc-payload-id": {
@@ -20442,125 +20759,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "squarelink": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/squarelink/-/squarelink-1.1.4.tgz",
-      "integrity": "sha512-VOLwNWhz/QgrGg5INvd7y/TddKDdS6/6FfjqtMys6nLVJA8h+h05WW5/YJLidHCSD0A+2VnPuL8m/lkP1bUk2g==",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "squarelink-provider-engine": "^15.0.5"
-      }
-    },
-    "squarelink-provider-engine": {
-      "version": "15.0.5",
-      "resolved": "https://registry.npmjs.org/squarelink-provider-engine/-/squarelink-provider-engine-15.0.5.tgz",
-      "integrity": "sha512-rl9586BLpN/ldujibbMsCfq+lEyY/YMkmWqYcbmKs6VUvB56fsIG23HvVFl1mPRUu7XIq4dOt+V+4G6+GcKTtQ==",
-      "requires": {
-        "async": "^2.5.0",
-        "backoff": "^2.5.0",
-        "clone": "^2.0.0",
-        "cross-fetch": "^2.1.0",
-        "eth-block-tracker": "^4.4.1",
-        "eth-json-rpc-filters": "^4.0.2",
-        "eth-json-rpc-infura": "^3.1.0",
-        "eth-json-rpc-middleware": "^4.1.1",
-        "eth-sig-util": "^1.4.2",
-        "ethereumjs-block": "^1.2.2",
-        "ethereumjs-tx": "^1.2.0",
-        "ethereumjs-util": "^5.1.5",
-        "ethereumjs-vm": "^2.3.4",
-        "json-rpc-error": "^2.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "promise-to-callback": "^1.0.0",
-        "readable-stream": "^2.2.9",
-        "request": "^2.85.0",
-        "semaphore": "^1.0.3",
-        "ws": "^5.1.1",
-        "xhr": "^2.2.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "cross-fetch": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
-          "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
-          "requires": {
-            "node-fetch": "2.1.2",
-            "whatwg-fetch": "2.0.4"
-          }
-        },
-        "eth-json-rpc-errors": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
-          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
-          "requires": {
-            "fast-safe-stringify": "^2.0.6"
-          }
-        },
-        "eth-json-rpc-middleware": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz",
-          "integrity": "sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==",
-          "requires": {
-            "btoa": "^1.2.1",
-            "clone": "^2.1.1",
-            "eth-json-rpc-errors": "^1.0.1",
-            "eth-query": "^2.1.2",
-            "eth-sig-util": "^1.4.2",
-            "ethereumjs-block": "^1.6.0",
-            "ethereumjs-tx": "^1.3.7",
-            "ethereumjs-util": "^5.1.2",
-            "ethereumjs-vm": "^2.6.0",
-            "fetch-ponyfill": "^4.0.0",
-            "json-rpc-engine": "^5.1.3",
-            "json-stable-stringify": "^1.0.1",
-            "pify": "^3.0.0",
-            "safe-event-emitter": "^1.0.1"
-          }
-        },
-        "eth-sig-util": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-          "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
-          "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-            "ethereumjs-util": "^5.1.1"
-          }
-        },
-        "ethereum-common": {
-          "version": "0.0.18",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-        },
-        "ethereumjs-tx": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-          "requires": {
-            "ethereum-common": "^0.0.18",
-            "ethereumjs-util": "^5.0.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        },
-        "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
     "squeak": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
@@ -21186,9 +21384,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -22265,13 +22463,13 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trezor-connect": {
-      "version": "8.1.17",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.1.17.tgz",
-      "integrity": "sha512-MwiafcFHfaOc1eXPmlnG3OEiRMEzxRODDky/pQjiUc+J265mNkaADJbwximTpKcv8WM0x4L3/aoDGre750scVw==",
+      "version": "8.1.19",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.1.19.tgz",
+      "integrity": "sha512-JU4qTkOhvq9EFdsbcNnECN9b13A7dFaPJiU4YAB9+zmlPHUjtswsSQN60aFR08pAovNVjPN5YbYuWYWYHVy/4w==",
       "requires": {
-        "@babel/runtime": "^7.11.2",
+        "@babel/runtime": "^7.12.5",
         "events": "^3.2.0",
-        "whatwg-fetch": "^3.4.1"
+        "whatwg-fetch": "^3.5.0"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -22713,9 +22911,9 @@
       }
     },
     "utf-8-validate": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
-      "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
+      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -23991,9 +24189,9 @@
       }
     },
     "websocket": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
-      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
+      "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
       "requires": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
@@ -24051,6 +24249,116 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
+          },
+          "dependencies": {
+            "call-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+              "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+              "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+              }
+            }
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+          "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+        },
+        "is-negative-zero": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+          "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+          "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+          "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@tippyjs/react": "4.1.0",
 		"bignumber.js": "9.0.0",
 		"bnc-notify": "1.5.0",
-		"bnc-onboard": "1.14.0",
+		"bnc-onboard": "1.18.0",
 		"color": "3.1.3",
 		"date-fns": "2.15.0",
 		"ethers": "5.0.8",


### PR DESCRIPTION
**Background**
The Lattice1 is GridPlus' next generation Ethereum-focused programmable hardware wallet. It is an always-online device with physically separated secure compute and Linux general compute environments. For more information, see https://gridplus.io/

**About this PR**
This PR adds the Lattice1 as a wallet option for bnc-notify and bumps the Blocknative Onboard library version from v1.14.0 to v1.18.0.

The Lattice1 can load smart contract ABIs so that interactions with your contracts are human-readable on the touchscreen which is drawn using the secure compute environment. This can help prevent man-in-the-middle attacks even when your computer is compromised. You can learn more about this functionality in [this blog post](https://blog.gridplus.io/readable-ethereum-transactions-a-new-standard-945c5e9ef2c7) and please let us know if you're interested in us preloading the Synthetix ABIs via an upcoming Lattice1 firmware release.

Thanks and please let us know if you have any questions!