### PR TITLE
281

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Fix incorrect values showing up on the mint and burn information panel (negative values were Math.abs() and showed large incorrect values)
 
 ## 18 Jan 2021
+
 - Fix staking info bug where the c-ratio was not calculated properly
 - Enable decimals to be inputted when custom mint or burn
 - Update SNX data package
+
+## 30 Jan 2021
+
+- Fix burn to target, when a user is under the c-ratio and does not have enough sUSD to burn to target, they are still allowed to click into the tile to see the required amount needed (Issue 281)
+- Removed the balance button when a user is one the burn to target flow and make it only appear on the custom tag

--- a/sections/staking/components/BurnTab/BurnTab.tsx
+++ b/sections/staking/components/BurnTab/BurnTab.tsx
@@ -204,6 +204,7 @@ const BurnTab: React.FC = () => {
 		let inputValue;
 		let isLocked;
 
+		/* If a user has more sUSD than the debt balance, the max burn amount is their debt balance, else it is just the balance they have */
 		const maxBurnAmount = debtBalance.isGreaterThan(sUSDBalance)
 			? toBigNumber(sUSDBalance)
 			: debtBalance;
@@ -239,7 +240,6 @@ const BurnTab: React.FC = () => {
 				return (
 					<BurnTiles
 						percentageTargetCRatio={percentageTargetCRatio}
-						maxBurnAmount={maxBurnAmount}
 						burnAmountToFixCRatio={burnAmountToFixCRatio}
 					/>
 				);

--- a/sections/staking/components/BurnTiles/BurnTiles.tsx
+++ b/sections/staking/components/BurnTiles/BurnTiles.tsx
@@ -20,7 +20,6 @@ import ButtonTile from '../ButtonTile';
 
 type BurnTilesProps = {
 	percentageTargetCRatio: BigNumber;
-	maxBurnAmount: BigNumber;
 	burnAmountToFixCRatio: BigNumber;
 };
 
@@ -28,11 +27,7 @@ const burnIcon = <Svg src={BurnCircle} />;
 const burnCustomIcon = <Img src={BurnCustomCircle} />; // TODO: investigate why it doesn't render correctly with <Svg /> (ids were replaced to be unique)
 const burnTargetIcon = <Svg src={BurnTargetCircle} />;
 
-const BurnTiles: React.FC<BurnTilesProps> = ({
-	percentageTargetCRatio,
-	maxBurnAmount,
-	burnAmountToFixCRatio,
-}) => {
+const BurnTiles: React.FC<BurnTilesProps> = ({ percentageTargetCRatio, burnAmountToFixCRatio }) => {
 	const { t } = useTranslation();
 	const [burnType, onBurnTypeChange] = useRecoilState(burnTypeState);
 	const onBurnChange = useSetRecoilState(amountToBurnState);

--- a/sections/staking/components/BurnTiles/BurnTiles.tsx
+++ b/sections/staking/components/BurnTiles/BurnTiles.tsx
@@ -52,11 +52,7 @@ const BurnTiles: React.FC<BurnTilesProps> = ({
 			<FlexDivRow>
 				<MarginedButtonTile
 					left={true}
-					disabled={
-						maxBurnAmount.isZero() ||
-						burnAmountToFixCRatio.isZero() ||
-						burnAmountToFixCRatio.isGreaterThan(maxBurnAmount)
-					}
+					disabled={burnAmountToFixCRatio.isZero()}
 					title={t('staking.actions.burn.tiles.target.title', {
 						targetCRatio: formatPercent(percentageTargetCRatio),
 					})}

--- a/sections/staking/components/StakingInput/StakingInput.tsx
+++ b/sections/staking/components/StakingInput/StakingInput.tsx
@@ -225,15 +225,12 @@ const StakingInput: React.FC<StakingInputProps> = ({
 					<IconButton onClick={() => onBack(null)}>
 						<Svg src={NavigationBack} />
 					</IconButton>
-					{!isMint &&
-						burnType != null &&
-						[(BurnActionType.CUSTOM, BurnActionType.TARGET)].includes(burnType) &&
-						maxBurnAmount && (
-							<BalanceButton variant="text" onClick={() => onInputChange(maxBurnAmount.toString())}>
-								<span>{t('common.wallet.balance')}</span>
-								{formatNumber(maxBurnAmount)}
-							</BalanceButton>
-						)}
+					{!isMint && burnType != null && [BurnActionType.CUSTOM].includes(burnType) && (
+						<BalanceButton variant="text" onClick={() => onInputChange(maxBurnAmount)}>
+							<span>{t('common.wallet.balance')}</span>
+							{formatNumber(maxBurnAmount ?? zeroBN)}
+						</BalanceButton>
+					)}
 				</HeaderRow>
 				<InputBox>
 					<Currency.Icon currencyKey={Synths.sUSD} width="50" height="50" />


### PR DESCRIPTION
**Feature to check**

- When a user is under the target c-ratio, and the do not have enough sUSD to burn the required amount to fix their c-ratio they can still click into the burn to target tile and see the required amount they need to burn to target


https://user-images.githubusercontent.com/39738607/106349323-39d0fc00-6321-11eb-9cef-044028eee273.mov

