### PR TITLE
Port debt tracking from mintr to  staker

### DIFF
--- a/components/Info/index.tsx
+++ b/components/Info/index.tsx
@@ -1,0 +1,32 @@
+
+import React, { useContext } from 'react';
+import styled from 'styled-components';
+
+const Info = () => {
+	return (
+		<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+			<g fill="none" fillRule="evenodd">
+				<circle
+					fill='grey'
+					cx="12"
+					cy="12"
+					r="11.5"
+				/>
+				<path
+					d="M9.4 10v-.832c0-.112.048-.16.16-.16h2.816c.112 0 .16.048.16.16v6.688h2.208c.112 0 .16.048.16.16v.864c0 .112-.048.16-.16.16H9.16c-.112 0-.16-.048-.16-.16v-.864c0-.112.048-.16.16-.16h2.128V10.16H9.56c-.112 0-.16-.048-.16-.16zm1.568-2.464V6.16c0-.112.048-.16.16-.16h1.376c.112 0 .16.048.16.16v1.376c0 .112-.048.16-.16.16h-1.376c-.112 0-.16-.048-.16-.16z"
+					fill='black'
+				/>
+			</g>
+		</svg>
+	);
+};
+
+
+const StyledCircle = styled(Info)`
+    .circle {
+        stroke: ${(props) => props.theme.colors.darkGradient1};
+        fill: ${(props) => props.theme.colors.darkGradient1};
+    }
+`
+
+export default Info;

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -29,6 +29,9 @@ export const ROUTES = {
 		Deposit: '/l2/deposit',
 		Migrate: '/l2/migrate',
 	},
+	Debt: {
+		Home: '/debt'
+	},
 };
 
 export default ROUTES;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"next": "10.0.1",
 		"next-compose-plugins": "2.2.0",
 		"next-optimized-images": "3.0.0-canary.10",
+		"numbro": "^2.3.2",
 		"react": "17.0.1",
 		"react-copy-to-clipboard": "5.0.2",
 		"react-countdown": "2.3.0",

--- a/pages/debt.tsx
+++ b/pages/debt.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { useTranslation, Trans } from 'react-i18next';
+import styled from 'styled-components';
+
+import { useRecoilValue } from 'recoil';
+import orderBy from 'lodash/orderBy';
+import last from 'lodash/last';
+
+import { 
+    ExternalLink, 
+    Tooltip, 
+    FlexDivColCentered,
+    StatsSection,
+    LineSpacer
+} from 'styles/common';
+
+import StatBox from 'components/StatBox';
+import Info from 'components/Info';
+
+import BalanceTable from 'sections/debt/BalanceTable';
+import DebtChart from 'sections/debt/DebtChart';
+import { Subtitle, Header, Container } from 'sections/debt/components/common';
+
+import { walletAddressState } from 'store/wallet';
+
+import useSynthIssuedQuery from 'queries/staking/useSynthIssuedQuery';
+import useSynthBurnedQuery from 'queries/staking/useSynthBurnedQuery';
+import useGetDebtDataQuery from 'queries/debt/useGetDebtDataQuery';
+import useGetDebtSnapshotQuery, { DebtSnapshotData } from 'queries/debt/useGetDebtSnapshotQuery';
+import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
+import { HistoricalStakingTransaction } from 'queries/staking/types';
+import useSynthsBalancesQuery from 'queries/walletBalances/useSynthsBalancesQuery';
+import { CryptoBalance } from 'queries/walletBalances/types';
+
+
+import { toBigNumber, zeroBN, formatCurrencyWithSign } from 'utils/formatters/number';
+
+type HistoricalDebtAndIssuance =  {
+    timestamp: number;
+    actualDebt: number;
+    issuanceDebt: number;
+}
+
+type DebtModel = {
+    mintAndBurnDebt: number;
+    actualDebt: number;
+}
+
+const DebtPage = () => {
+	const { t } = useTranslation();
+	const [debtModel, setDebtModel] = useState<DebtModel | null>();
+    const [historicalDebt, setHistoricalDebt] = useState<HistoricalDebtAndIssuance[]>([]);
+    const [sUSDRate, setsUSDRate] = useState<number>();
+    const [totalSynths, setTotalSynths] = useState<number>();
+    const [mintAndBurnDebtValue, setMintAndBurnDebtValue] = useState<number>();
+    const [totalSynthsValue, setTotalSynthsValue] = useState<number>();
+    const [actualDebtValue, setActualDebtValue] = useState<number>();
+    const [synthAssets, setSynthAssets] = useState<CryptoBalance[]>();
+    const walletAddress = useRecoilValue(walletAddressState);
+    const [fetchedSynths, setFetchedSynths] = useState<boolean>(false);
+
+    const issuedQuery = useSynthIssuedQuery(1000);
+    const burnedQuery = useSynthBurnedQuery(1000);
+    const debtSnapshotQuery = useGetDebtSnapshotQuery();
+    const debtDataQuery = useGetDebtDataQuery();
+    const exchangeRatesQuery = useExchangeRatesQuery();
+    const synthsBalancesQuery = useSynthsBalancesQuery();
+    const loaded = issuedQuery.isSuccess && burnedQuery.isSuccess 
+            && debtDataQuery.isSuccess && debtSnapshotQuery.isSuccess 
+            && synthsBalancesQuery.isSuccess;
+    
+    useEffect(() => {
+        if (loaded) {
+            const issued: HistoricalStakingTransaction[] = issuedQuery.data ?? [];
+            const burned: HistoricalStakingTransaction[] = burnedQuery.data ?? [];
+            const debtSnapshots: DebtSnapshotData[] = debtSnapshotQuery.data ?? [];
+
+            const sUSDRate = exchangeRatesQuery.data?.sUSD ?? 0;
+            const debtData = debtDataQuery.data ?? null;
+
+            const localTotalSynths = synthsBalancesQuery.isSuccess
+            ? synthsBalancesQuery.data?.totalUSDBalance ?? zeroBN
+            : zeroBN;
+
+            const synthBalances =
+                synthsBalancesQuery.isSuccess && synthsBalancesQuery.data != null
+                    ? synthsBalancesQuery.data
+                    : null;
+
+            const synthAssets = synthBalances?.balances ?? [];
+
+            // We concat both the events and order them (asc)
+            const burnEventsMap = burned.map(event => {
+                return { ...event, type: 'burn' };
+            });
+
+            const mintEventsMap = issued.map(event => {
+                return { ...event, type: 'mint' };
+            });
+
+            const eventBlocks = orderBy(burnEventsMap.concat(mintEventsMap), 'block', 'asc');
+            const historicalIssuanceAggregation: number[] = [];
+            // We set historicalIssuanceAggregation array, to store all the cumulative
+            // values of every mint and burns
+            eventBlocks.forEach((event, i) => {
+                const multiplier = event.type === 'burn' ? -1 : 1;
+                const aggregation =
+                    historicalIssuanceAggregation.length === 0
+                        ? multiplier * event.value
+                        : multiplier * event.value + historicalIssuanceAggregation[i - 1];
+
+                historicalIssuanceAggregation.push(aggregation);
+            });
+
+            let historicalDebtAndIssuance: HistoricalDebtAndIssuance[] = [];
+            // We merge both actual & issuance debt into an array
+            debtSnapshots.reverse().forEach((debtSnapshot, i) => {
+                historicalDebtAndIssuance.push({
+                    timestamp: debtSnapshot.timestamp,
+                    issuanceDebt: historicalIssuanceAggregation[i],
+                    actualDebt: debtSnapshot.debtBalanceOf,
+                });
+            });
+            // Last occurrence is the current state of the debt
+            // Issuance debt = last occurrence of the historicalDebtAndIssuance array
+            historicalDebtAndIssuance.push({
+                timestamp: new Date().getTime(),
+                actualDebt: toBigNumber(debtData?.debtBalance ?? 0).toNumber(),
+                issuanceDebt: last(historicalIssuanceAggregation) ?? 0,
+            });
+            setHistoricalDebt(historicalDebtAndIssuance);
+            setDebtModel({
+                mintAndBurnDebt: last(historicalIssuanceAggregation) ?? 0,
+                actualDebt: toBigNumber(debtData?.debtBalance ?? 0).toNumber(),
+            });
+            setsUSDRate(sUSDRate);
+            setTotalSynths(localTotalSynths.toNumber());
+            setSynthAssets(synthAssets);
+            setFetchedSynths(true)
+        }
+    }, [walletAddress, 
+        loaded]);
+    
+    useEffect(() => {
+        if (sUSDRate && debtModel?.actualDebt && debtModel.mintAndBurnDebt) {
+            const mintAndBurnDebtValue = debtModel.mintAndBurnDebt * sUSDRate;
+            const actualDebtValue = debtModel.actualDebt * sUSDRate;
+            const totalSynthsValue = totalSynths ? totalSynths * sUSDRate : 0;
+            setMintAndBurnDebtValue(mintAndBurnDebtValue)
+            setActualDebtValue(actualDebtValue)
+            setTotalSynthsValue(totalSynthsValue)
+
+        }}, [sUSDRate, debtModel, totalSynths, fetchedSynths]
+    )
+
+	return (
+		<>
+            <Head>
+            <title>{t('debt.page-title')}</title>
+            </Head>
+            <StatsSection>
+                <StyledStatsBox
+                        title={t('debt.track.data.issuedDebt')}
+                        value={formatCurrencyWithSign('$', mintAndBurnDebtValue ?? 0)}
+                    />
+                <StyledStatsBox
+                        title={t('debt.track.data.actualDebt')}
+                        value={formatCurrencyWithSign('$', actualDebtValue ?? 0)}
+                />
+                <StyledStatsBox
+                        title={t('debt.track.data.totalSynths')}
+                        value={formatCurrencyWithSign('$', totalSynthsValue ?? 0)}
+                />
+            </StatsSection>
+            <LineSpacer />
+            <Subtitle>
+                    {t('debt.track.subtitle')}
+                    <ExternalLink href="https://www.zapper.fi/">
+                        {' '}
+                        Zapper.fi <LinkArrow>↗</LinkArrow>
+                    </ExternalLink>
+            </Subtitle>
+            <Header>{t('debt.track.chart.title')}</Header>
+            <ChartBorderedContainer>
+                <StyledTooltip
+                    content={
+                        <Trans 
+                            i18nKey="debt.track.tooltip.info" 
+                            components={[<Strong />, <br />, <Strong />]}
+                        ></Trans>
+                    }
+                    ignoreAttributes={false}
+                >
+                    <TooltipIconContainer>
+                        <Info />
+                    </TooltipIconContainer>
+                </StyledTooltip>
+                <DebtChart data={historicalDebt} isLoaded={loaded}/>
+            </ChartBorderedContainer>
+            <BalanceTable 
+                assets={synthAssets ?? []}
+                title={t('debt.track.table.title')}
+                isLoaded={true}
+            />
+        </>
+	);
+};
+
+const StyledStatsBox = styled(StatBox)`
+	.value {
+		text-shadow: ${(props) => props.theme.colors.blueTextShadow};
+		color: ${(props) => props.theme.colors.black};
+	}
+`;
+
+const Strong = styled.strong`
+    font-family: ${(props) => props.theme.fonts.extended};
+`;
+
+const ChartBorderedContainer = styled(Container)`
+	justify-content: flex-start;
+    align-items: flex-start;
+    width: 100%;
+    background-color: ${(props) => props.theme.colors.navy};
+    margin-bottom: 1vh;
+`;
+
+const TooltipIconContainer = styled.div`
+	margin-left: 96%;
+	width: 23px;
+	height: 23px;
+`;
+
+const StyledTooltip = styled(Tooltip)`
+    background: ${(props) => props.theme.colors.mediumBlue};
+    font-family: ${(props) => props.theme.fonts.regular};
+    text-align: 'right';
+
+`;
+
+const LinkArrow = styled.span`
+	font-size: 10px;
+`;
+
+export default DebtPage

--- a/queries/debt/useGetDebtDataQuery.ts
+++ b/queries/debt/useGetDebtDataQuery.ts
@@ -10,7 +10,7 @@ import { isWalletConnectedState, networkState, walletAddressState } from 'store/
 import { appReadyState } from 'store/app';
 import { toBigNumber } from 'utils/formatters/number';
 
-type WalletDebtData = {
+export type WalletDebtData = {
 	targetCRatio: BigNumber;
 	currentCRatio: BigNumber;
 	transferable: BigNumber;

--- a/queries/debt/useGetDebtSnapshotQuery.ts
+++ b/queries/debt/useGetDebtSnapshotQuery.ts
@@ -1,25 +1,30 @@
 import { useQuery, QueryConfig } from 'react-query';
 import { useRecoilValue } from 'recoil';
+import { appReadyState } from 'store/app';
 
 import snxData from 'synthetix-data';
 
 import QUERY_KEYS from 'constants/queryKeys';
 
 import { isWalletConnectedState, networkState, walletAddressState } from 'store/wallet';
-import { HistoricalStakingTransaction } from './types';
 
-const useSynthIssuedQuery = (max?: number, options?: QueryConfig<HistoricalStakingTransaction[]>) => {
+export type DebtSnapshotData = {
+    account: string;
+    block: number;
+    debtBalanceOf: number;
+    timestamp: number;
+}
+const useSynthIssuedQuery = (options?: QueryConfig<DebtSnapshotData[]>) => {
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
 
-	return useQuery<HistoricalStakingTransaction[]>(
-		QUERY_KEYS.Staking.Issued(walletAddress ?? '', network?.id!),
+	return useQuery<DebtSnapshotData[]>(
+		QUERY_KEYS.Debt.DebtSnapshot(walletAddress ?? '', network?.id!),
 		async () => {
-			const transactions = (await snxData.snx.issued({
-				account: walletAddress,
-				max: max
-			})) as HistoricalStakingTransaction[];
+			const transactions = (await snxData.snx.debtSnapshot({
+				account: walletAddress, max: 1000
+			})) as DebtSnapshotData[];
 
 			return transactions;
 		},

--- a/queries/staking/useSynthBurnedQuery.tsx
+++ b/queries/staking/useSynthBurnedQuery.tsx
@@ -8,7 +8,7 @@ import QUERY_KEYS from 'constants/queryKeys';
 import { isWalletConnectedState, networkState, walletAddressState } from 'store/wallet';
 import { HistoricalStakingTransaction } from './types';
 
-const useSynthBurnedQuery = (options?: QueryConfig<HistoricalStakingTransaction[]>) => {
+const useSynthBurnedQuery = (max?: number, options?: QueryConfig<HistoricalStakingTransaction[]>) => {
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
@@ -18,6 +18,7 @@ const useSynthBurnedQuery = (options?: QueryConfig<HistoricalStakingTransaction[
 		async () => {
 			const transactions = (await snxData.snx.burned({
 				account: walletAddress,
+				max: max
 			})) as HistoricalStakingTransaction[];
 
 			return transactions;

--- a/sections/debt/BalanceTable.tsx
+++ b/sections/debt/BalanceTable.tsx
@@ -1,0 +1,168 @@
+import { FC, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CellProps } from 'react-table';
+import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/router';
+
+
+import Connector from 'containers/Connector';
+import Currency from 'components/Currency';
+import synthetix from 'lib/synthetix';
+
+import { appReadyState } from 'store/app';
+import { isWalletConnectedState } from 'store/wallet';
+
+import Table from 'components/Table';
+import Button from 'components/Button';
+
+
+import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
+import { CryptoBalance } from 'queries/walletBalances/types';
+import { Header } from 'sections/debt/components/common';
+
+import {
+    TableNoResults,
+    TableNoResultsTitle,
+	TableNoResultsDesc,
+	TableNoResultsButtonContainer,
+} from 'styles/common';
+
+import SynthPriceCol from '../synths/components/SynthPriceCol';
+import { isSynth } from 'utils/currencies';
+
+
+import ROUTES from 'constants/routes';
+
+type BalanceTableProps = {
+    title: string;
+    assets: CryptoBalance[];
+    isLoaded: boolean;
+};
+
+const BalanceTable: FC<BalanceTableProps> = ({ assets, title, isLoaded }) => {
+    const { t } = useTranslation();
+	const { connectWallet } = Connector.useContainer();
+	const isAppReady = useRecoilValue(appReadyState);
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+    const router = useRouter();
+    
+    const { selectedPriceCurrency, selectPriceCurrencyRate } = useSelectedPriceCurrency();
+
+    const assetColumns = useMemo(() => {
+		if (!isAppReady) {
+			return [];
+        }
+        const columns = [
+            {
+                Header: <>{t('debt.track.table.yourSynths')}</>,
+                accessor: 'currencyKey',
+                sortKey: 'basic',
+                Cell: (cellProps: CellProps<CryptoBalance, CryptoBalance['currencyKey']>) => {
+					const synthDesc =
+						synthetix.synthsMap != null ? synthetix.synthsMap[cellProps.value]?.description : '';
+
+					return (
+						<Currency.Name
+							currencyKey={cellProps.value}
+							name={
+								isSynth(cellProps.value)
+									? t('common.currency.synthetic-currency-name', { currencyName: synthDesc })
+									: undefined
+							}
+							showIcon={true}
+						/>
+					);
+				},
+                width: 200, 
+                sortable: true,
+				
+            },
+            {
+				Header: <>{t('debt.track.table.balance')}</>,
+				id: 'balance',
+				accessor: (originalRow: any) => originalRow.balance.toNumber(),
+				sortType: 'basic',
+				Cell: (cellProps: CellProps<CryptoBalance, CryptoBalance['balance']>) => (
+					<Currency.Amount
+						currencyKey={cellProps.row.original.currencyKey}
+						amount={cellProps.value}
+						totalValue={cellProps.row.original.usdBalance}
+						sign={selectedPriceCurrency.sign}
+						conversionRate={selectPriceCurrencyRate}
+					/>
+				),
+				width: 200,
+				sortable: true,
+            },
+            {
+				Header: <>{t('debt.track.table.price')}</>,
+				id: 'price',
+				sortType: 'basic',
+				Cell: (cellProps: CellProps<CryptoBalance>) => (
+					<SynthPriceCol currencyKey={cellProps.row.original.currencyKey} />
+				),
+				width: 200,
+				sortable: false,
+			},
+        ];
+        return columns;
+    }, [
+		t,
+		selectPriceCurrencyRate,
+		selectedPriceCurrency.sign,
+		isAppReady,
+    ]);
+    return (
+		<Container>
+			{isWalletConnected && <Header>{title}</Header>}
+			<StyledTable
+				palette="primary"
+				columns={assetColumns}
+				data={assets}
+				noResultsMessage={
+					!isWalletConnected ? (
+						<TableNoResults>
+							<TableNoResultsTitle>{t('common.wallet.no-wallet-connected')}</TableNoResultsTitle>
+							<TableNoResultsButtonContainer>
+								<Button variant="primary" onClick={connectWallet}>
+									{t('common.wallet.connect-wallet')}
+								</Button>
+							</TableNoResultsButtonContainer>
+						</TableNoResults>
+					) : isLoaded && assets.length === 0 ? (
+						<TableNoResults>
+							<TableNoResultsTitle>
+								{t('synths.assets.synths.table.no-synths.title')}
+							</TableNoResultsTitle>
+							<TableNoResultsDesc>
+								{t('synths.assets.synths.table.no-synths.desc')}
+							</TableNoResultsDesc>
+							<TableNoResultsButtonContainer>
+								<Button variant="primary" onClick={() => router.push(ROUTES.Staking.Home)}>
+									{t('common.stake-snx')}
+								</Button>
+							</TableNoResultsButtonContainer>
+						</TableNoResults>
+					) : undefined
+				}
+				showPagination={true}
+			/>
+		</Container>
+	);
+};
+
+const Container = styled.div`
+	padding-bottom: 20px;
+`;
+
+const StyledTable = styled(Table)`
+	.table-body-cell {
+		height: 70px;
+	}
+`;
+
+
+
+
+export default BalanceTable;

--- a/sections/debt/DebtChart.tsx
+++ b/sections/debt/DebtChart.tsx
@@ -1,0 +1,148 @@
+import React, { FC, useMemo, useContext } from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { format } from 'date-fns';
+import { ThemeContext } from 'styled-components';
+import numbro from 'numbro';
+import {
+	ResponsiveContainer,
+	LineChart,
+	Line,
+	XAxis,
+	YAxis,
+	Tooltip,
+	ReferenceLine,
+} from 'recharts';
+import { formatCurrency } from 'utils/formatters/number';
+
+const LEGEND_LABELS = {
+	actualDebt: 'debt.track.data.actualDebt',
+	issuanceDebt: 'debt.track.data.issuedDebt',
+};
+
+type Payload = {
+	color: string;
+	name: keyof typeof LEGEND_LABELS;
+	value: number;
+}
+
+type CustomTooltipProps = {
+	active?: boolean;
+	payload?: Payload[];
+	label?: Date;
+}
+
+type ChartDatum = {
+	issuanceDebt: number
+	actualDebt: number
+}
+
+type ChartProp = {
+	data: ChartDatum[],
+	isLoaded: boolean
+}
+
+
+const CustomTooltip: FC<CustomTooltipProps> = ({ active, payload, label }) => {
+	const { t } = useTranslation();
+	if (!active || !label) return null;
+
+	return (
+		<TooltipWrapper>
+			<Header>{format(new Date(label), 'MMM dd YYY, h:mma')}</Header>
+			<Legend>
+				{payload?.map(({ color, name, value }) => {
+					return (
+						<LegendRow key={`legend-${name}`}>
+							<LegendName>
+								<LegendIcon style={{ backgroundColor: color }} />
+								<LegendText>{t(LEGEND_LABELS[name])}</LegendText>
+							</LegendName>
+							<LegendText>{`${formatCurrency('sUSD', value)}`}</LegendText>
+						</LegendRow>
+					);
+				})}
+			</Legend>
+		</TooltipWrapper>
+	);
+};
+
+const Chart: FC<ChartProp> = ({ data, isLoaded }) => {
+	if (!data || data.length === 0 || !isLoaded) return null;
+	return (
+		<ResponsiveContainer width="100%" height={270}>
+			<LineChart margin={{ left: 0, top: 20, bottom: 0, right: 5 }} data={data}>
+				<XAxis
+					height={20}
+					dataKey="timestamp"
+					interval="preserveEnd"
+					tick={{ fontSize: 12, fontFamily: 'GT America Condensed-Bold' }}
+					axisLine={false}
+					tickLine={false}
+					tickFormatter={tick => format(new Date(tick), 'd MMM yy')}
+				/>
+				<YAxis
+					width={35}
+					domain={[0, 'auto']}
+					tickLine={false}
+					tickFormatter={tick => numbro(tick).format({ average: true })}
+					tick={{ fontSize: 12, fontFamily: 'GT America Condensed-Bold' }}
+				/>
+				<Tooltip
+					content={<CustomTooltip />}
+					contentStyle={{
+						zIndex: 1000,
+					}}
+				/>
+				<Line type="monotone" dataKey="issuanceDebt" stroke="#419EF8" strokeWidth={2} dot={false} />
+				<Line type="monotone" dataKey="actualDebt" stroke="#5C2AF5" strokeWidth={2} dot={false} />
+				<ReferenceLine y={0} isFront={false} strokeWidth={1}  />
+			</LineChart>
+		</ResponsiveContainer>
+	);
+};
+
+const TooltipWrapper = styled.div`
+	width: 250px;
+	background-color: ${props => props.theme.colors.black};
+	border: 1px solid ${props => props.theme.colors.blue};
+	border-radius: 2px;
+	padding: 16px;
+	text-align: left;
+`;
+
+const Header = styled.div`
+	font-size: 14px;
+	text-transform: none;
+	padding-bottom: 20px;
+`;
+
+const Legend = styled.div`
+	width: 100%;
+	font-family: ${(props) => props.theme.fonts.interSemiBold};
+`;
+
+const LegendRow = styled.div`
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
+`;
+
+const LegendName = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+const LegendIcon = styled.div`
+	width: 10px;
+	height: 10px;
+	background-color: red;
+	border-radius: 50%;
+	margin-right: 8px;
+`;
+
+const LegendText = styled.span`
+	font-family: ${(props) => props.theme.fonts.regular};
+	font-size: 12px;
+`;
+export default Chart;

--- a/sections/debt/components/common.ts
+++ b/sections/debt/components/common.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+import { FlexDivColCentered } from 'styles/common';
+
+export const Title = styled.p`
+	font-family: ${(props) => props.theme.fonts.condensedBold};
+	color: ${(props) => props.theme.colors.white};
+	font-size: 16px;
+	margin: 8px 24px;
+`;
+export const Subtitle = styled.p`
+	font-family: ${(props) => props.theme.fonts.condensedMedium};
+	color: ${(props) => props.theme.colors.white};
+	font-size: 14px;
+	height: 50px;
+	margin: 8px 35%;
+`;
+
+export const Header = styled.p`
+    color: ${(props) => props.theme.colors.white};
+	font-family: ${(props) => props.theme.fonts.extended};
+	font-size: 16px;
+    padding-bottom: 20px;
+`;
+
+export const Container = styled(FlexDivColCentered)`
+    padding: 20px;
+`;

--- a/sections/shared/Layout/constants.ts
+++ b/sections/shared/Layout/constants.ts
@@ -36,6 +36,10 @@ export const MENU_LINKS: MenuLinks = [
 		i18nLabel: 'sidenav.l2',
 		link: ROUTES.L2.Home,
 	},
+	{
+		i18nLabel: 'sidenav.debt',
+		link: ROUTES.Debt.Home,
+	},
 ];
 
 export const MIGRATE_MENU_LINKS: MenuLinks = [

--- a/translations/en.json
+++ b/translations/en.json
@@ -590,6 +590,31 @@
 			"connect-wallet-to-view": "Connect wallet to view transactions."
 		}
 	},
+	"debt": {
+		"page-title": "Debt Tracker",
+		"track": {
+			"title": "Track",
+			"subtitle": "Track your debt over time, with charts via",
+			"data": {
+				"actualDebt": "Actual Debt",
+				"totalSynths": "Total Synths",
+				"issuedDebt": "Issued Debt"
+			},
+			"chart": {
+				"title": "Debt Over Time"
+			},
+
+			"table": {
+				"title": "Synths Balance",
+				"yourSynths": "Your synths",
+				"balance": "Balance",
+				"price": "Price"
+			},
+			"tooltip": {
+				"info": "<0>Issued debt:</0> This displays the total of all your mints and burns over time, revealing how only your C-Ratio management has affected your debt.<1 /><2>Actual debt:</2> This displays your total debt over time."
+			}
+		}
+	},
 	"synths": {
 		"page-title": "Synths | Synthetix Staking",
 		"assets": {
@@ -619,6 +644,7 @@
 		"escrow": "Escrow",
 		"history": "History",
 		"l2": "Layer 2",
+		"debt": "Debt Tracker",
 		"bars": {
 			"c-ratio": "c-ratio",
 			"t-ratio": "target",

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -41,7 +41,6 @@ export const minBN = BigNumber.minimum;
 export const formatNumber = (value: NumericValue, options?: FormatNumberOptions) => {
 	const prefix = options?.prefix;
 	const suffix = options?.suffix;
-
 	const formattedValue = [];
 	if (prefix) {
 		formattedValue.push(prefix);
@@ -97,10 +96,10 @@ const getPrecision = (amount: NumericValue) => {
 
 // TODO: use a library for this, because the sign does not always appear on the left. (perhaps something like number.toLocaleString)
 export const formatCurrencyWithSign = (
-	sign: string | null | undefined,
+	sign: string,
 	value: NumericValue,
 	decimals?: number
-) => `${sign}${formatCurrency(String(value), decimals || getPrecision(value))}`;
+) => `${sign}${formatCurrency(sign, value)}`;
 
 export const formatCurrencyWithKey = (
 	currencyKey: CurrencyKey,


### PR DESCRIPTION
Opening this PR to tackle the first part of [this issue](https://github.com/Synthetixio/staking/issues/305) re: [this](https://twitter.com/kaiynne/status/1357807384379281408).

Major additions:
1. Added base level routes to get to the DebtTracker from the menu bar.
2. Added a query to get DebtSnapshots for a period of time.
3. Balance table and graph and showing current debt positions, over time respectively.
4. Fixes to formatCurrencyWithSign to make the func work properly.


Let me know what else you need from me - thanks!