### PR TITLE
Add Lattice1 Support and Bump BNC-Onboard to v1.19.0

### DIFF
--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -21,6 +21,12 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 			wallets: [
 				{ walletName: 'metamask', preferred: true },
 				{
+					walletName: 'lattice',
+					appName: 'Synthetix',
+					rpcUrl: infuraRpc,
+					preferred: true,
+				},
+				{
 					walletName: 'ledger',
 					rpcUrl: infuraRpc,
 					preferred: true,
@@ -43,11 +49,9 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 					apiKey: process.env.NEXT_PUBLIC_PORTIS_APP_ID,
 				},
 				{ walletName: 'trust', rpcUrl: infuraRpc },
-				{ walletName: 'dapper' },
 				{ walletName: 'walletLink', rpcUrl: infuraRpc },
 				{ walletName: 'torus' },
 				{ walletName: 'status' },
-				// { walletName: 'unilogin' },
 				{ walletName: 'authereum' },
 			],
 		},

--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -24,7 +24,6 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 					walletName: 'lattice',
 					appName: 'Synthetix',
 					rpcUrl: infuraRpc,
-					preferred: true,
 				},
 				{
 					walletName: 'ledger',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@tippyjs/react": "4.1.0",
 		"bignumber.js": "9.0.0",
 		"bnc-notify": "1.5.0",
-		"bnc-onboard": "1.14.0",
+		"bnc-onboard": "1.19.0",
 		"color": "3.1.3",
 		"date-fns": "2.15.0",
 		"ethers": "5.0.8",


### PR DESCRIPTION
**Background**
The Lattice1 is GridPlus' next generation Ethereum-focused programmable hardware wallet. It is an always-online device with physically separated secure compute and Linux general compute environments. For more information, see https://gridplus.io/

**About this PR**
This PR adds the Lattice1 as a wallet option for bnc-notify and bumps the Blocknative Onboard library version from v1.14.0 to v1.19.0. It also removes deprecated wallets no longer supported by the current version of the library (Dapper and Unilogin).

The Lattice1 can load smart contract ABIs so that interactions with your contracts are human-readable on the touchscreen which is drawn using the secure compute environment. This can help prevent man-in-the-middle attacks even when your computer is compromised. You can learn more about this functionality in [this blog post](https://blog.gridplus.io/readable-ethereum-transactions-a-new-standard-945c5e9ef2c7) and please let us know if you're interested in us preloading the Synthetix ABIs into all Lattice1s via an upcoming firmware release.

Thanks and please let us know if you have any questions!

EDIT: This is a revision of [an earlier PR I closed](https://github.com/Synthetixio/staking/pull/272) since Blocknative is now on to a newer version of Onboard and [this PR](https://github.com/Synthetixio/staking/pull/291) closed a few minutes ago by @clementbalestrat.