### PR TITLE
/synth page decimals fix

### DIFF
--- a/components/Currency/CurrencyAmount/CurrencyAmount.tsx
+++ b/components/Currency/CurrencyAmount/CurrencyAmount.tsx
@@ -29,7 +29,7 @@ export const CurrencyAmount: FC<CurrencyAmountProps> = ({
 			{formatCurrency(
 				currencyKey,
 				conversionRate != null ? toBigNumber(totalValue).dividedBy(conversionRate) : totalValue,
-				{ sign }
+				{ sign, decimals:2 }
 			)}
 		</TotalValue>
 	</Container>

--- a/components/Currency/CurrencyAmount/CurrencyAmount.tsx
+++ b/components/Currency/CurrencyAmount/CurrencyAmount.tsx
@@ -8,28 +8,30 @@ import { CurrencyKey } from 'constants/currency';
 import { ContainerRowMixin } from '../common';
 
 type CurrencyAmountProps = {
-	currencyKey: CurrencyKey;
+	amountCurrencyKey: CurrencyKey;
 	amount: NumericValue;
+    valueCurrencyKey: CurrencyKey;
 	totalValue: NumericValue;
 	sign?: string;
 	conversionRate?: NumericValue | null;
 };
 
 export const CurrencyAmount: FC<CurrencyAmountProps> = ({
-	currencyKey,
+	amountCurrencyKey,
 	amount,
+    valueCurrencyKey,
 	totalValue,
 	sign,
 	conversionRate,
 	...rest
 }) => (
 	<Container {...rest}>
-		<Amount className="amount">{formatCurrency(currencyKey, amount)}</Amount>
+		<Amount className="amount">{formatCurrency(amountCurrencyKey, amount)}</Amount>
 		<TotalValue className="total-value">
 			{formatCurrency(
-				currencyKey,
+				valueCurrencyKey,
 				conversionRate != null ? toBigNumber(totalValue).dividedBy(conversionRate) : totalValue,
-				{ sign, decimals:2 }
+				{ sign }
 			)}
 		</TotalValue>
 	</Container>

--- a/components/Currency/CurrencyAmount/CurrencyAmount.tsx
+++ b/components/Currency/CurrencyAmount/CurrencyAmount.tsx
@@ -10,7 +10,7 @@ import { ContainerRowMixin } from '../common';
 type CurrencyAmountProps = {
 	amountCurrencyKey: CurrencyKey;
 	amount: NumericValue;
-    valueCurrencyKey: CurrencyKey;
+	valueCurrencyKey: CurrencyKey;
 	totalValue: NumericValue;
 	sign?: string;
 	conversionRate?: NumericValue | null;
@@ -19,7 +19,7 @@ type CurrencyAmountProps = {
 export const CurrencyAmount: FC<CurrencyAmountProps> = ({
 	amountCurrencyKey,
 	amount,
-    valueCurrencyKey,
+	valueCurrencyKey,
 	totalValue,
 	sign,
 	conversionRate,

--- a/sections/synths/AssetsTable.tsx
+++ b/sections/synths/AssetsTable.tsx
@@ -105,7 +105,7 @@ const AssetsTable: FC<AssetsTableProps> = ({
 					<Currency.Amount
 						amountCurrencyKey={cellProps.row.original.currencyKey}
 						amount={cellProps.value}
-                        valueCurrencyKey={selectedPriceCurrency.name}
+						valueCurrencyKey={selectedPriceCurrency.name}
 						totalValue={cellProps.row.original.usdBalance}
 						sign={selectedPriceCurrency.sign}
 						conversionRate={selectPriceCurrencyRate}

--- a/sections/synths/AssetsTable.tsx
+++ b/sections/synths/AssetsTable.tsx
@@ -103,8 +103,9 @@ const AssetsTable: FC<AssetsTableProps> = ({
 				sortType: 'basic',
 				Cell: (cellProps: CellProps<CryptoBalance, CryptoBalance['balance']>) => (
 					<Currency.Amount
-						currencyKey={cellProps.row.original.currencyKey}
+						amountCurrencyKey={cellProps.row.original.currencyKey}
 						amount={cellProps.value}
+                        valueCurrencyKey={selectedPriceCurrency.name}
 						totalValue={cellProps.row.original.usdBalance}
 						sign={selectedPriceCurrency.sign}
 						conversionRate={selectPriceCurrencyRate}


### PR DESCRIPTION
noticed that some USD values displayed on the /synths page had too many decimals and it was confusing me. dug a little deeper and realized it stemmed from the Currency.Amount component using the same currencyKey to determine how many decimals to use for both crypto and fiat amounts. updated Currency.Amount to accept an amountCurrencyKey and valueCurrencyKey and updated AssetsTable to provide the valueCurrencyKey separately

before:
<img width="763" alt="Capture" src="https://user-images.githubusercontent.com/78625401/107445663-c2a22180-6af1-11eb-913b-ddb2486ac874.PNG">

after:
<img width="743" alt="Capture2" src="https://user-images.githubusercontent.com/78625401/107445668-c5047b80-6af1-11eb-9818-14d746d92676.PNG">
