### PR TITLE
fix(Minting): show correct APR for curve after a sucessful mint

### DIFF
--- a/sections/staking/components/TxSent/ActionCompleted.tsx
+++ b/sections/staking/components/TxSent/ActionCompleted.tsx
@@ -3,6 +3,8 @@ import { Svg } from 'react-optimized-image';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
+import { useSetRecoilState } from 'recoil';
+import Link from 'next/link';
 
 import {
 	FlexDivRowCentered,
@@ -11,12 +13,24 @@ import {
 	ExternalLink,
 	boxShadowBlue,
 } from 'styles/common';
+
 import Success from 'assets/svg/app/success.svg';
-import Link from 'next/link';
 
 import { Transaction } from 'constants/network';
 import ROUTES from 'constants/routes';
 import { CryptoCurrency, Synths } from 'constants/currency';
+
+import Etherscan from 'containers/Etherscan';
+
+import { formatPercent } from 'utils/formatters/number';
+
+import { amountToBurnState, amountToMintState, burnTypeState, mintTypeState } from 'store/staking';
+
+import Currency from 'components/Currency';
+
+import useLPData from 'hooks/useLPData';
+
+import { LP } from 'sections/earn/types';
 
 import {
 	SectionHeader,
@@ -28,10 +42,6 @@ import {
 	MiddleSection,
 	IconContainer,
 } from './common';
-import Etherscan from 'containers/Etherscan';
-import { amountToBurnState, amountToMintState, burnTypeState, mintTypeState } from 'store/staking';
-import { useSetRecoilState } from 'recoil';
-import Currency from 'components/Currency';
 
 type ActionCompletedProps = {
 	setTransactionState: (tx: Transaction) => void;
@@ -50,6 +60,7 @@ const ActionCompleted: React.FC<ActionCompletedProps> = ({
 }) => {
 	const { t } = useTranslation();
 	const { push } = useRouter();
+	const lpData = useLPData();
 	const { etherscanInstance } = Etherscan.useContainer();
 	const link = etherscanInstance != null ? etherscanInstance.txLink(hash ?? '') : undefined;
 	const onMintTypeChange = useSetRecoilState(mintTypeState);
@@ -111,8 +122,7 @@ const ActionCompleted: React.FC<ActionCompletedProps> = ({
 						</MiddleInfoSection>
 						<RightInfoSection>
 							<AprText>{t('staking.actions.mint.completed.est-apr')}</AprText>
-							{/* @TODO: Replace with variable APR */}
-							<AprValue>14%</AprValue>
+							<AprValue>{formatPercent(lpData[LP.CURVE_sUSD].APR)}</AprValue>
 						</RightInfoSection>
 					</MainInfoBox>
 				</Link>

--- a/sections/staking/components/TxSent/ActionCompleted.tsx
+++ b/sections/staking/components/TxSent/ActionCompleted.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { useSetRecoilState } from 'recoil';
-import Link from 'next/link';
 
 import {
 	FlexDivRowCentered,
@@ -114,7 +113,7 @@ const ActionCompleted: React.FC<ActionCompletedProps> = ({
 				{t('staking.actions.mint.completed.title', { synth: Synths.sUSD })}
 			</SectionHeader>
 			<MiddleSection>
-				<Link href={ROUTES.Earn.Home}>
+				<StyledExternalLink href={ROUTES.Earn.sUSD_EXTERNAL}>
 					<MainInfoBox>
 						<Currency.Icon currencyKey={CryptoCurrency.CRV} width="20" height="20" />
 						<MiddleInfoSection>
@@ -125,7 +124,7 @@ const ActionCompleted: React.FC<ActionCompletedProps> = ({
 							<AprValue>{formatPercent(lpData[LP.CURVE_sUSD].APR)}</AprValue>
 						</RightInfoSection>
 					</MainInfoBox>
-				</Link>
+				</StyledExternalLink>
 			</MiddleSection>
 			<SectionSubtext>{t('staking.actions.mint.completed.subtext')}</SectionSubtext>
 			<ButtonWrap>
@@ -216,6 +215,11 @@ const RightButton = styled(BaseButton)`
 	color: ${(props) => props.theme.colors.blue};
 	text-transform: uppercase;
 
+`;
+
+const StyledExternalLink = styled(ExternalLink)`
+	display: block;
+	width: 100%;
 `;
 
 export default ActionCompleted;


### PR DESCRIPTION
Fixes #296

Currently, the link goes to back `/earn` - need to clarify if this should go to https://www.curve.fi/susdv2/ instead?