### PR TITLE
fix(L2-Deposit): remove extra spacing on deposit SNX tab

### DIFF
--- a/sections/layer2/deposit/DepositTab/DepositTab.tsx
+++ b/sections/layer2/deposit/DepositTab/DepositTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
 
 import { TabContainer } from '../../components/common';
 import { Transaction } from 'constants/network';
@@ -120,7 +121,7 @@ const DepositTab = () => {
 	};
 
 	return (
-		<TabContainer>
+		<StyledTabContainer>
 			{!isApproved ? (
 				<ApproveModal
 					description={t('layer2.actions.deposit.action.approve.description')}
@@ -142,8 +143,12 @@ const DepositTab = () => {
 				transactionState={transactionState}
 				setTransactionState={setTransactionState}
 			/>
-		</TabContainer>
+		</StyledTabContainer>
 	);
 };
+
+const StyledTabContainer = styled(TabContainer)`
+	padding: 0;
+`;
 
 export default DepositTab;


### PR DESCRIPTION
Fixes #286 

Here's how it looks now:
<img width="529" alt="Screen Shot 2021-02-15 at 4 16 50 pm" src="https://user-images.githubusercontent.com/254095/107908184-89fac000-6fa9-11eb-8f42-950394f1f43c.png">
<img width="510" alt="Screen Shot 2021-02-15 at 4 16 35 pm" src="https://user-images.githubusercontent.com/254095/107908191-8cf5b080-6fa9-11eb-8da2-d49bed84661d.png">

The extra spacing caused this issue, I only modified it on the deposit page, so that other pages won't be affected (since the extra padding is actually needed)