### PR TITLE
fix: NaN under SNX TVL on /earn

### DIFF
--- a/queries/staking/helpers.ts
+++ b/queries/staking/helpers.ts
@@ -1,0 +1,20 @@
+import { pageResults } from 'synthetix-data';
+
+const synthetixSnx = 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix';
+
+export const getHolders = async () =>
+	pageResults({
+		api: synthetixSnx,
+		query: {
+			entity: 'snxholders',
+			selection: {
+				orderBy: 'collateral',
+				orderDirection: 'desc',
+				where: {
+					block_gt: 5873222,
+				},
+			},
+			properties: ['collateral', 'debtEntryAtIndex', 'initialDebtOwnership'],
+		},
+		max: 1000,
+	});

--- a/queries/staking/useSNXLockedValueQuery.ts
+++ b/queries/staking/useSNXLockedValueQuery.ts
@@ -46,20 +46,24 @@ const useSNXLockedValueQuery = (options?: QueryConfig<number>) => {
 			let snxTotal = 0;
 			let snxLocked = 0;
 
-			for (const { collateral, debtEntryAtIndex, initialDebtOwnership } of holders) {
-				const formattedCollateral = Number(synthetix.js?.utils.formatEther(collateral));
+			for (const {
+				collateral: unformattedCollateral,
+				debtEntryAtIndex,
+				initialDebtOwnership,
+			} of holders) {
+				const collateral = Number(synthetix.js?.utils.formatEther(unformattedCollateral));
 
 				let debtBalance =
 					((totalIssuedSynths * lastDebtLedgerEntry) / debtEntryAtIndex) * initialDebtOwnership;
-				let collateralRatio = debtBalance / formattedCollateral / usdToSnxPrice;
+				let collateralRatio = debtBalance / collateral / usdToSnxPrice;
 
 				if (isNaN(debtBalance)) {
 					debtBalance = 0;
 					collateralRatio = 0;
 				}
-				const lockedSnx = formattedCollateral * Math.min(1, collateralRatio / issuanceRatio);
+				const lockedSnx = collateral * Math.min(1, collateralRatio / issuanceRatio);
 
-				snxTotal += Number(formattedCollateral);
+				snxTotal += Number(collateral);
 				snxLocked += Number(lockedSnx);
 			}
 


### PR DESCRIPTION
directly querying subgraph for holders

same as this https://github.com/Synthetixio/stats/commit/b1171bf3f1022d1fb38cc021ef55ab05493a835a