### PR TITLE
Add sETH incentives and disable 0% apys

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -211,9 +211,15 @@ export const QUERY_KEYS = {
 		],
 	},
 	ShortRewards: {
-		iBTC: (walletAddress: string, networkId: NetworkId) => [
+		sBTC: (walletAddress: string, networkId: NetworkId) => [
 			'shortRewards',
-			'iBTC',
+			'sBTC',
+			walletAddress,
+			networkId,
+		],
+		sETH: (walletAddress: string, networkId: NetworkId) => [
+			'shortRewards',
+			'sETH',
 			walletAddress,
 			networkId,
 		],

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -32,6 +32,8 @@ export const ROUTES = {
 		DHT_LP: '/earn/DHT-LP',
 		sBTC_EXTERNAL: 'https://kwenta.io/shorting',
 		sBTC_SHORT: '/earn/sBTC-SHORT',
+		sETH_EXTERNAL: 'https://kwenta.io/shorting',
+		sETH_SHORT: '/earn/sETH-SHORT',
 	},
 	L2: {
 		Home: '/l2',

--- a/hooks/useShortRewardsData.ts
+++ b/hooks/useShortRewardsData.ts
@@ -3,6 +3,7 @@ import { WEEKS_IN_YEAR } from 'constants/date';
 import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import { ShortRewardsData } from 'queries/shorts/types';
 import useSBTCShortsQuery from 'queries/shorts/useSBTCShortsQuery';
+import useSETHShortsQuery from 'queries/shorts/useSETHShortsQuery';
 
 type SRData = {
 	[name: string]: {
@@ -16,6 +17,7 @@ const useShortRewardsData = (): SRData => {
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const SNXRate = exchangeRatesQuery.data?.SNX ?? 0;
 	const usesBTCRewards = useSBTCShortsQuery();
+	const usesETHRewards = useSETHShortsQuery();
 
 	const sBTCOpenInterestUSD = usesBTCRewards.data?.openInterestUSD ?? 0;
 
@@ -24,11 +26,23 @@ const useShortRewardsData = (): SRData => {
 			? ((usesBTCRewards.data.distribution * SNXRate) / sBTCOpenInterestUSD) * WEEKS_IN_YEAR
 			: 0;
 
+	const sETHOpenInterestUSD = usesETHRewards.data?.openInterestUSD ?? 0;
+
+	const sETHAPR =
+		usesETHRewards.data?.distribution && SNXRate && sETHOpenInterestUSD
+			? ((usesETHRewards.data.distribution * SNXRate) / sETHOpenInterestUSD) * WEEKS_IN_YEAR
+			: 0;
+
 	return {
 		[Synths.sBTC]: {
 			APR: sBTCAPR,
 			OI: sBTCOpenInterestUSD,
 			data: usesBTCRewards.data,
+		},
+		[Synths.sETH]: {
+			APR: sETHAPR,
+			OI: sETHOpenInterestUSD,
+			data: usesETHRewards.data,
 		},
 	};
 };

--- a/queries/shorts/useSBTCShortsQuery.ts
+++ b/queries/shorts/useSBTCShortsQuery.ts
@@ -4,7 +4,12 @@ import { useRecoilValue } from 'recoil';
 import synthetix from 'lib/synthetix';
 import QUERY_KEYS from 'constants/queryKeys';
 import { appReadyState } from 'store/app';
-import { walletAddressState, isWalletConnectedState, networkState } from 'store/wallet';
+import {
+	walletAddressState,
+	isWalletConnectedState,
+	networkState,
+	isMainnetState,
+} from 'store/wallet';
 import { Synths } from 'constants/currency';
 import { ShortRewardsData } from './types';
 
@@ -13,6 +18,7 @@ const useSBTCShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
+	const isMainnet = useRecoilValue(isMainnetState);
 
 	return useQuery<ShortRewardsData>(
 		QUERY_KEYS.ShortRewards.sBTC(walletAddress ?? '', network?.id!),
@@ -66,7 +72,7 @@ const useSBTCShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected,
+			enabled: isAppReady && isWalletConnected && isMainnet,
 			...options,
 		}
 	);

--- a/queries/shorts/useSETHShortsQuery.ts
+++ b/queries/shorts/useSETHShortsQuery.ts
@@ -4,7 +4,12 @@ import { useRecoilValue } from 'recoil';
 import synthetix from 'lib/synthetix';
 import QUERY_KEYS from 'constants/queryKeys';
 import { appReadyState } from 'store/app';
-import { walletAddressState, isWalletConnectedState, networkState } from 'store/wallet';
+import {
+	walletAddressState,
+	isWalletConnectedState,
+	networkState,
+	isMainnetState,
+} from 'store/wallet';
 import { Synths } from 'constants/currency';
 import { ShortRewardsData } from './types';
 
@@ -13,6 +18,7 @@ const useSETHShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
+	const isMainnet = useRecoilValue(isMainnetState);
 
 	return useQuery<ShortRewardsData>(
 		QUERY_KEYS.ShortRewards.sETH(walletAddress ?? '', network?.id!),
@@ -66,7 +72,7 @@ const useSETHShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected,
+			enabled: isAppReady && isWalletConnected && isMainnet,
 			...options,
 		}
 	);

--- a/queries/shorts/useSETHShortsQuery.ts
+++ b/queries/shorts/useSETHShortsQuery.ts
@@ -8,37 +8,37 @@ import { walletAddressState, isWalletConnectedState, networkState } from 'store/
 import { Synths } from 'constants/currency';
 import { ShortRewardsData } from './types';
 
-const useSBTCShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
+const useSETHShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
 	const isAppReady = useRecoilValue(appReadyState);
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
 
 	return useQuery<ShortRewardsData>(
-		QUERY_KEYS.ShortRewards.sBTC(walletAddress ?? '', network?.id!),
+		QUERY_KEYS.ShortRewards.sETH(walletAddress ?? '', network?.id!),
 		async () => {
 			const {
-				contracts: { CollateralManager, ExchangeRates, ShortingRewardssBTC },
+				contracts: { CollateralManager, ExchangeRates, ShortingRewardssETH },
 			} = synthetix.js!;
 
-			const getDuration = ShortingRewardssBTC.DURATION || ShortingRewardssBTC.rewardsDuration;
+			const getDuration = ShortingRewardssETH.DURATION || ShortingRewardssETH.rewardsDuration;
 
 			const [
 				duration,
 				rate,
 				periodFinish,
-				sBtcSNXRewards,
-				sBtcStaked,
+				sEthSNXRewards,
+				sEthStaked,
 				openInterestBN,
 				[assetUSDPriceBN],
 			] = await Promise.all([
 				getDuration(),
-				ShortingRewardssBTC.rewardRate(),
-				ShortingRewardssBTC.periodFinish(),
-				ShortingRewardssBTC.earned(walletAddress),
-				ShortingRewardssBTC.balanceOf(walletAddress),
-				CollateralManager.short(synthetix.js?.toBytes32(Synths.sBTC)),
-				ExchangeRates.rateAndInvalid(synthetix.js?.toBytes32(Synths.sBTC)),
+				ShortingRewardssETH.rewardRate(),
+				ShortingRewardssETH.periodFinish(),
+				ShortingRewardssETH.earned(walletAddress),
+				ShortingRewardssETH.balanceOf(walletAddress),
+				CollateralManager.short(synthetix.js?.toBytes32(Synths.sETH)),
+				ExchangeRates.rateAndInvalid(synthetix.js?.toBytes32(Synths.sETH)),
 			]);
 
 			const durationInWeeks = Number(duration) / 3600 / 24 / 7;
@@ -50,8 +50,8 @@ const useSBTCShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
 			const [openInterest, assetUSDPrice, rewards, staked] = [
 				openInterestBN,
 				assetUSDPriceBN,
-				sBtcSNXRewards,
-				sBtcStaked,
+				sEthSNXRewards,
+				sEthStaked,
 			].map((data) => Number(synthetix.js?.utils.formatEther(data)));
 
 			const openInterestUSD = openInterest * assetUSDPrice;
@@ -72,4 +72,4 @@ const useSBTCShortsQuery = (options?: QueryConfig<ShortRewardsData>) => {
 	);
 };
 
-export default useSBTCShortsQuery;
+export default useSETHShortsQuery;

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
@@ -106,19 +106,21 @@ const LayoutLayerOne: FC = () => {
 					supplier: 'Synthetix',
 				}),
 				externalLink: ROUTES.Earn.sBTC_EXTERNAL,
+				isDisabled: shortData[Synths.sBTC].APR === 0,
 			},
 			{
 				gridLocations: ['col-3', 'col-5', 'row-2', 'row-3'],
 				icon: (
 					<GlowingCircle variant="green" size="md">
-						<Currency.Icon currencyKey={Synths.iETH} width="32" height="32" />
+						<Currency.Icon currencyKey={Synths.sETH} width="32" height="32" />
 					</GlowingCircle>
 				),
 				title: t('dashboard.actions.earn.title', {
-					percent: formatPercent(lpData[Synths.iETH].APR, { minDecimals: 0 }),
+					percent: formatPercent(shortData[Synths.sETH].APR, { minDecimals: 0 }),
 				}),
-				copy: t('dashboard.actions.earn.copy', { asset: Synths.iETH, supplier: 'Synthetix' }),
-				link: ROUTES.Earn.iETH_LP,
+				copy: t('dashboard.actions.loans.copy', { asset: Synths.sETH, supplier: 'Synthetix' }),
+				externalLink: ROUTES.Earn.sETH_EXTERNAL,
+				isDisabled: shortData[Synths.sETH].APR === 0,
 			},
 			{
 				gridLocations: ['col-1', 'col-2', 'row-3', 'row-4'],
@@ -136,6 +138,7 @@ const LayoutLayerOne: FC = () => {
 				}),
 				tooltip: t('common.tooltip.external', { link: 'Curve Finance' }),
 				externalLink: ROUTES.Earn.sUSD_EXTERNAL,
+				isDisabled: lpData[LP.CURVE_sUSD].APR === 0,
 			},
 			{
 				gridLocations: ['col-2', 'col-3', 'row-3', 'row-4'],
@@ -152,9 +155,10 @@ const LayoutLayerOne: FC = () => {
 					supplier: 'Uniswap',
 				}),
 				link: ROUTES.Earn.DHT_LP,
+				isDisabled: lpData[LP.UNISWAP_DHT].APR === 0,
 			},
 			{
-				gridLocations: ['col-3', 'col-5', 'row-3', 'row-4'],
+				gridLocations: ['col-3', 'col-4', 'row-3', 'row-4'],
 				icon: (
 					<GlowingCircle variant="green" size="md">
 						<Currency.Icon currencyKey={Synths.sTSLA} width="28" height="28" />
@@ -168,6 +172,7 @@ const LayoutLayerOne: FC = () => {
 					supplier: 'Synthetix',
 				}),
 				link: ROUTES.Earn.sTLSA_LP,
+				isDisabled: lpData[LP.BALANCER_sTSLA].APR === 0,
 			},
 		];
 	}, [t, lpData, currentCRatio, targetCRatio, stakingRewards, tradingRewards, shortData]);

--- a/sections/earn/IncentivesMainnet.tsx
+++ b/sections/earn/IncentivesMainnet.tsx
@@ -129,6 +129,24 @@ const Incentives: FC<IncentivesProps> = ({
 							externalLink: ROUTES.Earn.sBTC_EXTERNAL,
 						},
 						{
+							title: t('earn.incentives.options.seth.title'),
+							subtitle: t('earn.incentives.options.seth.subtitle'),
+							apr: shortData[Synths.sETH].APR,
+							tvl: shortData[Synths.sETH].OI,
+							staked: {
+								balance: shortData[Synths.sETH].data?.staked ?? 0,
+								asset: Synths.sETH,
+							},
+							rewards: shortData[Synths.sETH].data?.rewards ?? 0,
+							periodStarted: now - (shortData[Synths.sETH].data?.duration ?? 0),
+							periodFinish: shortData[Synths.sETH].data?.periodFinish ?? 0,
+							claimed: (shortData[Synths.sETH].data?.rewards ?? 0) > 0 ? false : NOT_APPLICABLE,
+							now,
+							tab: Tab.sETH_SHORT,
+							route: ROUTES.Earn.sETH_SHORT,
+							externalLink: ROUTES.Earn.sETH_EXTERNAL,
+						},
+						{
 							title: t('earn.incentives.options.stsla.title'),
 							subtitle: t('earn.incentives.options.stsla.subtitle'),
 							apr: lpData[LP.BALANCER_sTSLA].APR,
@@ -232,6 +250,7 @@ const Incentives: FC<IncentivesProps> = ({
 				lpData[LP.CURVE_sUSD].data &&
 				lpData[LP.CURVE_sEURO].data &&
 				shortData[Synths.sBTC].data &&
+				shortData[Synths.sETH].data &&
 				lpData[Synths.iETH].data &&
 				lpData[Synths.iBTC].data &&
 				lpData[LP.BALANCER_sTSLA].data
@@ -294,10 +313,10 @@ const Incentives: FC<IncentivesProps> = ({
 						userBalanceBN={lpData[Synths.iETH].data?.userBalanceBN ?? zeroBN}
 						stakedAsset={Synths.iETH}
 						allowance={lpData[Synths.iETH].data?.allowance ?? null}
-						tokenRewards={incentives[1].rewards}
-						staked={incentives[1].staked.balance}
+						tokenRewards={lpData[Synths.iETH].data?.rewards ?? 0}
+						staked={lpData[Synths.iETH].data?.staked ?? 0}
 						stakedBN={lpData[Synths.iETH].data?.stakedBN ?? zeroBN}
-						needsToSettle={incentives[1].needsToSettle}
+						needsToSettle={lpData[Synths.iETH].data?.needsToSettle}
 					/>
 				)}
 				{activeTab === Tab.sTLSA_LP && (
@@ -306,10 +325,10 @@ const Incentives: FC<IncentivesProps> = ({
 						userBalanceBN={lpData[LP.BALANCER_sTSLA].data?.userBalanceBN ?? zeroBN}
 						stakedAsset={LP.BALANCER_sTSLA}
 						allowance={lpData[LP.BALANCER_sTSLA].data?.allowance ?? null}
-						tokenRewards={incentives[3].rewards}
-						staked={incentives[3].staked.balance}
+						tokenRewards={lpData[LP.BALANCER_sTSLA].data?.rewards ?? 0}
+						staked={lpData[LP.BALANCER_sTSLA].data?.staked ?? 0}
 						stakedBN={lpData[LP.BALANCER_sTSLA].data?.stakedBN ?? zeroBN}
-						needsToSettle={incentives[3].needsToSettle}
+						needsToSettle={lpData[LP.BALANCER_sTSLA].data?.needsToSettle}
 					/>
 				)}
 				{activeTab === Tab.DHT_LP && (
@@ -318,10 +337,10 @@ const Incentives: FC<IncentivesProps> = ({
 						userBalanceBN={lpData[LP.UNISWAP_DHT].data?.userBalanceBN ?? zeroBN}
 						stakedAsset={LP.UNISWAP_DHT}
 						allowance={lpData[LP.UNISWAP_DHT].data?.allowance ?? null}
-						tokenRewards={incentives[5].rewards}
-						staked={incentives[5].staked.balance}
+						tokenRewards={lpData[LP.UNISWAP_DHT].data?.rewards ?? 0}
+						staked={lpData[LP.UNISWAP_DHT].data?.staked ?? 0}
 						stakedBN={lpData[LP.UNISWAP_DHT].data?.stakedBN ?? zeroBN}
-						needsToSettle={incentives[5].needsToSettle}
+						needsToSettle={lpData[LP.UNISWAP_DHT].data?.needsToSettle}
 						secondTokenRate={lpData[LP.UNISWAP_DHT].data?.price ?? 0}
 					/>
 				)}
@@ -331,10 +350,10 @@ const Incentives: FC<IncentivesProps> = ({
 						userBalanceBN={lpData[Synths.iBTC].data?.userBalanceBN ?? zeroBN}
 						stakedAsset={Synths.iBTC}
 						allowance={lpData[Synths.iBTC].data?.allowance ?? null}
-						tokenRewards={incentives[6].rewards}
-						staked={incentives[6].staked.balance}
+						tokenRewards={lpData[Synths.iBTC].data?.rewards ?? 0}
+						staked={lpData[Synths.iBTC].data?.staked ?? 0}
 						stakedBN={lpData[Synths.iBTC].data?.stakedBN ?? zeroBN}
-						needsToSettle={incentives[6].needsToSettle}
+						needsToSettle={lpData[Synths.iBTC].data?.needsToSettle}
 					/>
 				)}
 			</TabContainer>

--- a/sections/earn/IncentivesTable.tsx
+++ b/sections/earn/IncentivesTable.tsx
@@ -35,7 +35,7 @@ import {
 	TableNoResultsButtonContainer,
 	TableNoResultsTitle,
 } from 'styles/common';
-import { CryptoCurrency, CurrencyKey, Synths } from 'constants/currency';
+import { CryptoCurrency, CurrencyKey } from 'constants/currency';
 import { DURATION_SEPARATOR } from 'constants/date';
 
 import ROUTES from 'constants/routes';

--- a/sections/earn/IncentivesTable.tsx
+++ b/sections/earn/IncentivesTable.tsx
@@ -179,7 +179,7 @@ const IncentivesTable: FC<IncentivesTableProps> = ({ data, isLoaded, activeTab }
 					const isDualRewards = cellProps.row.original.staked.asset === LP.UNISWAP_DHT;
 					if (
 						!cellProps.row.original.externalLink ||
-						cellProps.row.original.staked.asset === Synths.sBTC
+						cellProps.row.original.staked.asset !== LP.CURVE_sUSD
 					) {
 						return (
 							<CellContainer>

--- a/sections/earn/types.ts
+++ b/sections/earn/types.ts
@@ -6,6 +6,7 @@ export enum Tab {
 	sTLSA_LP = 'sTSLA-LP',
 	DHT_LP = 'DHT-LP',
 	sBTC_SHORT = 'sBTC Short',
+	sETH_SHORT = 'sETH Short',
 	iBTC_LP = 'iBTC-LP',
 }
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -422,6 +422,11 @@
 					"description": "Opening a short allows you to earn SNX rewards. <0>Learn more.<0>",
 					"subtitle": "sBTC Short Rewards"
 				},
+				"seth": {
+					"title": "Synthetix",
+					"description": "Opening a short allows you to earn SNX rewards. <0>Learn more.<0>",
+					"subtitle": "sETH Short Rewards"
+				},
 				"stsla": {
 					"title": "Balancer",
 					"description": "Stake sTLSA Balancer Pool LP to earn SNX rewards. <0>Add liquidity on Balancer here<0>.",


### PR DESCRIPTION
This feature branch adds the sETH shorting rewards to incentives "/earn".

Others
- Fixes the reference of the lpData via the index, made it reference instead the object so that adding more incentives would not mess up the index of the array.
- Disable 0% apy on the home layouts 