### PR TITLE
chore: fix L2 withdraw SNX label

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -605,7 +605,7 @@
 		},
 		"withdraw": {
 			"info": {
-				"title": "Withdraw SNX from Layer 1 to Layer 2",
+				"title": "Withdraw SNX from Layer 2 to Layer 1",
 				"subtitle": "Warning: withdrawing your SNX will take 7-10 days to be received on L1, during which time you will not have access to your funds. Once you initiate a withdrawal you will not be able to cancel it.",
 				"no-withdrawals": "No withdrawal history",
 				"table": {


### PR DESCRIPTION
Fix for wrong label shown on "Withdraw" page on L2.
<img width="826" alt="Screenshot 2021-04-01 at 13 19 14" src="https://user-images.githubusercontent.com/8177587/113286732-e19c8300-92ec-11eb-80f7-98111cad898c.png">