### PR TITLE
filter council nominations to exclude invalid proposals

### DIFF
--- a/constants/nominations.json
+++ b/constants/nominations.json
@@ -1,5 +1,5 @@
 {
-	"3": [
+	"QmT8e5oWmyyM61gnjv5dRx5L5dcX7SZ24Ako62dPS7oHhE": [
 		{
 			"discord": "NaotoSake",
 			"address": "0xFA6C97f0efFaB1Ce8D7CD80EB96DDF2ac6bf0e38"
@@ -89,7 +89,7 @@
 			"address": "0x5f024dba3bcbbfe6dece556dbb59c5776aec5903"
 		}
 	],
-	"2": [
+	"QmPyFrvjPRzqsxCpcUFdHU2hWGWV4EJa99ahFATtTyxyZ6": [
 		{
 			"discord": "BigPenny",
 			"address": "0x9cFc4cfB2aa99bedc98d52E2DCc0Eb010F20718f"
@@ -167,7 +167,7 @@
 			"address": "0x5fC5528E1f363B48c375Ae2Db28BBE82533d8439"
 		}
 	],
-	"1": [
+	"QmQREHVu11dognYVbHhNSHrxeiMAzoChAsqvD68VtqAo69": [
 		{
 			"discord": "Danijel",
 			"address": "0x461783a831e6db52d68ba2f3194f6fd1e0087e04"

--- a/queries/gov/useProposals.tsx
+++ b/queries/gov/useProposals.tsx
@@ -13,6 +13,7 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import Connector from 'containers/Connector';
 import { ethers } from 'ethers';
 import CouncilDilution from 'contracts/councilDilution.js';
+import CouncilNominations from 'constants/nominations.json';
 
 const useProposals = (spaceKey: SPACE_KEY, options?: QueryConfig<Proposal[]>) => {
 	const isAppReady = useRecoilValue(appReadyState);
@@ -52,6 +53,57 @@ const useProposals = (spaceKey: SPACE_KEY, options?: QueryConfig<Proposal[]>) =>
 				const validHashes = hashes
 					.filter((e: string) => e !== '')
 					.map((hash) => hash.toLowerCase());
+				const mappedProposals = proposalContent.map(async (proposal) => {
+					if (validHashes.includes(proposal.authorIpfsHash.toLowerCase())) {
+						const block = parseInt(proposal.msg.payload.snapshot);
+						const currentBlock = provider?.getBlockNumber() ?? 0;
+						const blockTag = block > currentBlock ? 'latest' : block;
+
+						let { voterAddresses } = await Promise.resolve(
+							axios.get(PROPOSAL(spaceKey, proposal.authorIpfsHash)).then((response) => {
+								return {
+									voterAddresses: Object.keys(response.data).map((address) =>
+										ethers.utils.getAddress(address)
+									) as string[],
+								};
+							})
+						);
+
+						const [scores]: any = await Promise.all([
+							snapshot.utils.getScores(
+								spaceKey,
+								space.strategies,
+								space.network,
+								provider,
+								voterAddresses,
+								blockTag
+							),
+						]);
+
+						let voteCount = 0;
+
+						space.strategies.forEach((_, i: number) => {
+							let arrayOfVotes = Object.values(scores[i]) as number[];
+							voteCount = voteCount + arrayOfVotes.filter((score: number) => score > 0).length;
+						});
+
+						return {
+							...proposal,
+							votes: voteCount,
+						};
+					} else {
+						return null;
+					}
+				});
+				const resolvedProposals = await Promise.all(mappedProposals);
+				return resolvedProposals.filter((e) => e !== null);
+			} else if (spaceKey === SPACE_KEY.COUNCIL) {
+				const nominationHashes = Object.keys(CouncilNominations);
+
+				const validHashes = proposalHashes
+					.filter((e: string) => nominationHashes.includes(e))
+					.map((hash) => hash.toLowerCase());
+
 				const mappedProposals = proposalContent.map(async (proposal) => {
 					if (validHashes.includes(proposal.authorIpfsHash.toLowerCase())) {
 						const block = parseInt(proposal.msg.payload.snapshot);

--- a/sections/gov/components/Proposal/Content.tsx
+++ b/sections/gov/components/Proposal/Content.tsx
@@ -78,14 +78,16 @@ const Content: React.FC<ContentProps> = ({ onBack }) => {
 				const currentElectionMembers = CouncilNominations as any;
 				const mappedProfiles = [] as any;
 
-				currentElectionMembers[electionCount].forEach((member: any, i: number) => {
-					mappedProfiles.push({
-						address: member.address,
-						name: member.discord,
-						key: i,
+				if (currentElectionMembers[proposal.authorIpfsHash]) {
+					currentElectionMembers[proposal.authorIpfsHash].forEach((member: any, i: number) => {
+						mappedProfiles.push({
+							address: member.address,
+							name: member.discord,
+							key: i,
+						});
 					});
-				});
-				setChoices(shuffle(mappedProfiles));
+					setChoices(shuffle(mappedProfiles));
+				}
 			};
 			loadDiscordNames();
 		}

--- a/sections/gov/components/Proposal/Results.tsx
+++ b/sections/gov/components/Proposal/Results.tsx
@@ -30,12 +30,14 @@ const Results: React.FC<ResultsProps> = ({ hash }) => {
 				const currentElectionMembers = CouncilNominations as any;
 				const mappedProfiles = [] as any;
 
-				currentElectionMembers[electionCount].forEach((member: any) => {
-					mappedProfiles.push({
-						address: member.address,
-						name: member.discord,
+				if (currentElectionMembers[hash]) {
+					currentElectionMembers[hash].forEach((member: any) => {
+						mappedProfiles.push({
+							address: member.address,
+							name: member.discord,
+						});
 					});
-				});
+				}
 				setChoices(mappedProfiles);
 			};
 			loadDiscordNames();
@@ -48,7 +50,7 @@ const Results: React.FC<ResultsProps> = ({ hash }) => {
 		}
 	}, [proposal, activeTab]);
 
-	if (proposal.isSuccess && proposal.data && choices) {
+	if (proposal.isSuccess && proposal.data && choices && choices.length > 0) {
 		const { data } = proposal;
 
 		const totalVotes = data.totalVotesBalances !== 0 ? data.totalVotesBalances : 1;

--- a/sections/gov/components/Proposal/Results.tsx
+++ b/sections/gov/components/Proposal/Results.tsx
@@ -42,7 +42,7 @@ const Results: React.FC<ResultsProps> = ({ hash }) => {
 			};
 			loadDiscordNames();
 		}
-	}, [proposal, activeTab, electionCount]);
+	}, [proposal, activeTab, electionCount, hash]);
 
 	useEffect(() => {
 		if (proposal && activeTab !== SPACE_KEY.COUNCIL) {


### PR DESCRIPTION
Since the council elections depend on a json that maps their addresses to their discord identity, there were some cases where if a invalid election was created, the proposals would not render correctly.