### PR TITLE
Use last available value for issued debt if missing at index

### DIFF
--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -69,7 +69,7 @@ const useHistoricalDebtData = () => {
 			debtHistory.reverse().forEach((debtSnapshot, i) => {
 				historicalDebtAndIssuance.push({
 					timestamp: debtSnapshot.timestamp,
-					issuanceDebt: historicalIssuanceAggregation[i],
+					issuanceDebt: historicalIssuanceAggregation[i] ?? last(historicalIssuanceAggregation),
 					actualDebt: debtSnapshot.debtBalanceOf,
 				});
 			});


### PR DESCRIPTION
Fixes issue like this:
![image](https://user-images.githubusercontent.com/12561777/114830203-9cb72880-9d91-11eb-9b79-b6d76d8f7c26.png)

With change:
![image](https://user-images.githubusercontent.com/12561777/114830298-b0628f00-9d91-11eb-9b04-8013a6da3637.png)
