### PR TITLE
fix: workaround for stats load issue on ethers curve gauges contracts

### DIFF
--- a/utils/web3.ts
+++ b/utils/web3.ts
@@ -1,0 +1,8 @@
+import Web3 from 'web3';
+
+let web3: any;
+
+export function makeWeb3Contract(address: string, abi: any) {
+	if (!web3) web3 = new Web3(window.ethereum);
+	return new web3.eth.Contract(abi, address);
+}


### PR DESCRIPTION
temp fix for issue where ethers instances of curve gauges contracts is returning weird "out of gas" error on some calls. probably won't work if user is connected to a none-web3 provider.