### PR TITLE
Remove decimals on proposal start & end timestamps

### DIFF
--- a/sections/gov/components/Create/index.tsx
+++ b/sections/gov/components/Create/index.tsx
@@ -55,7 +55,7 @@ const Index: React.FC<IndexProps> = ({ onBack }) => {
 	const { signer } = Connector.useContainer();
 
 	const sanitiseTimestamp = (timestamp: number) => {
-		return timestamp / 1e3;
+		return (timestamp / 1e3).toFixed();
 	};
 
 	const validSubmission = useMemo(() => {


### PR DESCRIPTION
Remove decimals on proposals start and end timestamps, Snapshot hub now will reject proposals with decimals on timestamps. 