### PR TITLE
Refactor Staking dApp 

### DIFF
--- a/components/Currency/CurrencyIcon/CurrencyIcon.tsx
+++ b/components/Currency/CurrencyIcon/CurrencyIcon.tsx
@@ -10,9 +10,15 @@ import useSynthetixTokenList from 'queries/tokenLists/useSynthetixTokenList';
 import useZapperTokenList from 'queries/tokenLists/useZapperTokenList';
 import { FlexDivCentered } from 'styles/common';
 
+export enum CurrencyIconType {
+	SYNTH = 'synth',
+	ASSET = 'asset',
+	TOKEN = 'token',
+}
+
 type CurrencyIconProps = {
 	currencyKey: CurrencyKey;
-	type?: 'synth' | 'asset' | 'token';
+	type?: CurrencyIconType;
 	className?: string;
 	width?: string;
 	height?: string;
@@ -68,7 +74,7 @@ export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest
 				return <Img src={ETHIcon} {...props} />;
 			}
 			case CryptoCurrency.SNX: {
-				return <img src={SNXIcon} {...props} />;
+				return <img src={SNXIcon} {...props} alt="snx-icon" />;
 			}
 			default:
 				return (
@@ -80,6 +86,7 @@ export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest
 						}
 						onError={() => setIsError(true)}
 						{...props}
+						alt={currencyKey}
 					/>
 				);
 		}

--- a/components/Currency/CurrencyIcon/CurrencyIcon.tsx
+++ b/components/Currency/CurrencyIcon/CurrencyIcon.tsx
@@ -1,118 +1,42 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import Img from 'react-optimized-image';
+import styled from 'styled-components';
 
-// Crypto
-import BTCIcon from 'assets/svg/currencies/crypto/BTC.svg';
 import ETHIcon from 'assets/svg/currencies/crypto/ETH.svg';
-import CRVIcon from 'assets/svg/currencies/crypto/CRV.svg';
-import renBTCIcon from 'assets/svg/currencies/crypto/BTC.svg'; // todo: use actual RENBTC icon
-// import XRPIcon from 'assets/svg/currencies/crypto/XRP.svg';
-// import BCHIcon from 'assets/svg/currencies/crypto/BCH.svg';
-// import LTCIcon from 'assets/svg/currencies/crypto/LTC.svg';
-// import EOSIcon from 'assets/svg/currencies/crypto/EOS.svg';
-// import BNBIcon from 'assets/svg/currencies/crypto/BNB.svg';
-// import XTZIcon from 'assets/svg/currencies/crypto/XTZ.svg';
-// import XMRIcon from 'assets/svg/currencies/crypto/XMR.svg';
-// import ADAIcon from 'assets/svg/currencies/crypto/ADA.svg';
-// import LINKIcon from 'assets/svg/currencies/crypto/LINK.svg';
-// import TRXIcon from 'assets/svg/currencies/crypto/TRX.svg';
-// import DASHIcon from 'assets/svg/currencies/crypto/DASH.svg';
-// import ETCIcon from 'assets/svg/currencies/crypto/ETC.svg';
-import SNXIcon from '@synthetixio/assets/snx/SNX.svg';
-// import COMPIcon from 'assets/svg/currencies/crypto/COMP.svg';
-// import RENIcon from 'assets/svg/currencies/crypto/REN.svg';
-// import LENDIcon from 'assets/svg/currencies/crypto/LEND.svg';
-// import KNCIcon from 'assets/svg/currencies/crypto/KNC.svg';
-// Commodity
-// import GOLDIcon from 'assets/svg/currencies/commodity/GOLD.svg';
-// import SILVERIcon from 'assets/svg/currencies/commodity/SILVER.svg';
-// Equities
-// import FTSEIcon from 'assets/svg/currencies/equities/FTSE.svg';
-// import NIKKEIIcon from 'assets/svg/currencies/equities/NIKKEI.svg';
-// Fiat
-// import AUDIcon from 'assets/svg/currencies/fiat/AUD.svg';a
-// import CADIcon  from 'assets/svg/currencies/fiat/CAD.svg';
-// import CHFIcon from 'assets/svg/currencies/fiat/CHF.svg';
-// import EURIcon from 'assets/svg/currencies/fiat/EUR.svg';
-// import GBPIcon from 'assets/svg/currencies/fiat/GBP.svg';
-// import JPYIcon from 'assets/svg/currencies/fiat/JPY.svg';
-// import KRWIcon  from 'assets/svg/currencies/fiat/KRW.svg';
-// import USDIcon from 'assets/svg/currencies/fiat/USD.svg';
-// Indices
-// import CEXIcon from 'assets/svg/currencies/indices/CEX.svg';
-// import DEFIIcon from 'assets/svg/currencies/indices/DEFI.svg';
 
-// Crypto Synths
-import sBTCIcon from '@synthetixio/assets/synths/sBTC.svg';
-import sETHIcon from '@synthetixio/assets/synths/sETH.svg';
-import sXRPIcon from '@synthetixio/assets/synths/sXRP.svg';
-import sBCHIcon from '@synthetixio/assets/synths/sBCH.svg';
-import sLTCIcon from '@synthetixio/assets/synths/sLTC.svg';
-import sEOSIcon from '@synthetixio/assets/synths/sEOS.svg';
-import sBNBIcon from '@synthetixio/assets/synths/sBNB.svg';
-import sXTZIcon from '@synthetixio/assets/synths/sXTZ.svg';
-import sXMRIcon from '@synthetixio/assets/synths/sXMR.svg';
-import sADAIcon from '@synthetixio/assets/synths/sADA.svg';
-import sLINKIcon from '@synthetixio/assets/synths/sLINK.svg';
-import sTRXIcon from '@synthetixio/assets/synths/sTRX.svg';
-import sDASHIcon from '@synthetixio/assets/synths/sDASH.svg';
-import sETCIcon from '@synthetixio/assets/synths/sETC.svg';
-import iBTCIcon from '@synthetixio/assets/synths/iBTC.svg';
-import iETHIcon from '@synthetixio/assets/synths/iETH.svg';
-import iXRPIcon from '@synthetixio/assets/synths/iXRP.svg';
-import iBCHIcon from '@synthetixio/assets/synths/iBCH.svg';
-import iLTCIcon from '@synthetixio/assets/synths/iLTC.svg';
-import iEOSIcon from '@synthetixio/assets/synths/iEOS.svg';
-import iBNBIcon from '@synthetixio/assets/synths/iBNB.svg';
-import iXTZIcon from '@synthetixio/assets/synths/iXTZ.svg';
-import iXMRIcon from '@synthetixio/assets/synths/iXMR.svg';
-import iADAIcon from '@synthetixio/assets/synths/iADA.svg';
-import iLINKIcon from '@synthetixio/assets/synths/iLINK.svg';
-import iTRXIcon from '@synthetixio/assets/synths/iTRX.svg';
-import iDASHIcon from '@synthetixio/assets/synths/iDASH.svg';
-import iETCIcon from '@synthetixio/assets/synths/iETC.svg';
-import sTSLAIcon from '@synthetixio/assets/synths/sTSLA.svg';
-import sFBIcon from '@synthetixio/assets/synths/sFB.svg';
-import sAAPLIcon from '@synthetixio/assets/synths/sAAPL.svg';
-import sAMZNIcon from '@synthetixio/assets/synths/sAMZN.svg';
-import sNFLXIcon from '@synthetixio/assets/synths/sNFLX.svg';
-import sGOOGIcon from '@synthetixio/assets/synths/sGOOG.svg';
-import DHTIcon from 'assets/svg/currencies/crypto/DHEDGE.svg';
+import { CryptoCurrency, CurrencyKey } from 'constants/currency';
 
-// Commoditiy Synths
-import sXAUIcon from '@synthetixio/assets/synths/sXAU.svg';
-import sXAGIcon from '@synthetixio/assets/synths/sXAG.svg';
-import sOILIcon from '@synthetixio/assets/synths/sOIL.svg';
-import iOILIcon from '@synthetixio/assets/synths/iOIL.svg';
-
-// Crypto Index Synths
-import sDEFIIcon from '@synthetixio/assets/synths/sDEFI.svg';
-import sCEXIcon from '@synthetixio/assets/synths/sCEX.svg';
-import iDEFIIcon from '@synthetixio/assets/synths/iDEFI.svg';
-import iCEXIcon from '@synthetixio/assets/synths/iCEX.svg';
-// Equity Synths
-import sFTSEIcon from '@synthetixio/assets/synths/sFTSE.svg';
-import sNIKKEIIcon from '@synthetixio/assets/synths/sNIKKEI.svg';
-// Forex Synths
-import sEURIcon from '@synthetixio/assets/synths/sEUR.svg';
-import sJPYIcon from '@synthetixio/assets/synths/sJPY.svg';
-import sUSDIcon from '@synthetixio/assets/synths/sUSD.svg';
-import sAUDIcon from '@synthetixio/assets/synths/sAUD.svg';
-import sGBPIcon from '@synthetixio/assets/synths/sGBP.svg';
-import sCHFIcon from '@synthetixio/assets/synths/sCHF.svg';
-
-import { CryptoCurrency, CurrencyKey, Synths } from 'constants/currency';
-import { LP } from 'sections/earn/types';
+import useSynthetixTokenList from 'queries/tokenLists/useSynthetixTokenList';
+import useZapperTokenList from 'queries/tokenLists/useZapperTokenList';
+import { FlexDivCentered } from 'styles/common';
 
 type CurrencyIconProps = {
 	currencyKey: CurrencyKey;
-	type?: 'synth' | 'asset';
+	type?: 'synth' | 'asset' | 'token';
 	className?: string;
 	width?: string;
 	height?: string;
 };
 
-export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type = 'synth', ...rest }) => {
+export const SNXIcon =
+	'https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/snx/SNX.svg';
+
+export const getSynthIcon = (currencyKey: CurrencyKey) =>
+	`https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/synths/${currencyKey}.svg`;
+
+export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest }) => {
+	const [isError, setIsError] = useState<boolean>(false);
+
+	const synthetixTokenListQuery = useSynthetixTokenList();
+	const synthetixTokenListMap = synthetixTokenListQuery.isSuccess
+		? synthetixTokenListQuery.data?.tokensMap ?? null
+		: null;
+
+	const ZapperTokenListQuery = useZapperTokenList();
+	const ZapperTokenListMap = ZapperTokenListQuery.isSuccess
+		? ZapperTokenListQuery.data?.tokensMap ?? null
+		: null;
+
 	const props = {
 		width: '24px',
 		height: '24px',
@@ -120,195 +44,92 @@ export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type = 'synth
 		...rest,
 	};
 
-	// TODO: next-optimized-images does not support dynamic imports yet... so it needs to be manually defined.
+	const defaultIcon = (
+		<Placeholder style={{ width: props.width, height: props.height }}>{currencyKey}</Placeholder>
+	);
 
-	// most of the "asset" types were disabled since they were not widely used.
-	switch (currencyKey) {
-		case CryptoCurrency.BTC: {
-			return <Img src={BTCIcon} {...props} />;
-		}
-		case CryptoCurrency.ETH: {
-			return <Img src={ETHIcon} {...props} />;
-		}
-		case CryptoCurrency.SNX: {
-			return <Img src={SNXIcon} {...props} />;
-		}
-		case CryptoCurrency.RENBTC: {
-			return <Img src={renBTCIcon} {...props} />;
-		}
-		case CryptoCurrency.CRV: {
-			return <Img src={CRVIcon} {...props} />;
-		}
+	if (isError) {
+		return defaultIcon;
+	}
 
-		case Synths.sBTC: {
-			return <Img src={sBTCIcon} {...props} />;
+	if (type === 'token') {
+		return ZapperTokenListMap != null && ZapperTokenListMap[currencyKey] != null ? (
+			<ZapperTokenIcon
+				src={ZapperTokenListMap[currencyKey].logoURI}
+				onError={() => setIsError(true)}
+				{...props}
+			/>
+		) : (
+			defaultIcon
+		);
+	} else {
+		switch (currencyKey) {
+			case CryptoCurrency.ETH: {
+				return <Img src={ETHIcon} {...props} />;
+			}
+			case CryptoCurrency.SNX: {
+				return <img src={SNXIcon} {...props} />;
+			}
+			default:
+				return (
+					<img
+						src={
+							synthetixTokenListMap != null && synthetixTokenListMap[currencyKey] != null
+								? synthetixTokenListMap[currencyKey].logoURI
+								: getSynthIcon(currencyKey)
+						}
+						onError={() => setIsError(true)}
+						{...props}
+					/>
+				);
 		}
-		case Synths.sETH: {
-			return type === 'synth' ? (
-				<Img src={sETHIcon} {...props} />
-			) : (
-				<Img src={ETHIcon} {...props} />
-			);
-		}
-		case Synths.sXRP: {
-			return <Img src={sXRPIcon} {...props} />;
-		}
-		case Synths.sBCH: {
-			return <Img src={sBCHIcon} {...props} />;
-		}
-		case Synths.sLTC: {
-			return <Img src={sLTCIcon} {...props} />;
-		}
-		case Synths.sEOS: {
-			return <Img src={sEOSIcon} {...props} />;
-		}
-		case Synths.sBNB: {
-			return <Img src={sBNBIcon} {...props} />;
-		}
-		case Synths.sXTZ: {
-			return <Img src={sXTZIcon} {...props} />;
-		}
-		case Synths.sXMR: {
-			return <Img src={sXMRIcon} {...props} />;
-		}
-		case Synths.sADA: {
-			return <Img src={sADAIcon} {...props} />;
-		}
-		case Synths.sLINK: {
-			return <Img src={sLINKIcon} {...props} />;
-		}
-		case Synths.sTRX: {
-			return <Img src={sTRXIcon} {...props} />;
-		}
-		case Synths.sDASH: {
-			return <Img src={sDASHIcon} {...props} />;
-		}
-		case Synths.sETC: {
-			return <Img src={sETCIcon} {...props} />;
-		}
-		case Synths.iBTC: {
-			return <Img src={iBTCIcon} {...props} />;
-		}
-		case Synths.iETH: {
-			return <Img src={iETHIcon} {...props} />;
-		}
-		case Synths.iXRP: {
-			return <Img src={iXRPIcon} {...props} />;
-		}
-		case Synths.iBCH: {
-			return <Img src={iBCHIcon} {...props} />;
-		}
-		case Synths.iLTC: {
-			return <Img src={iLTCIcon} {...props} />;
-		}
-		case Synths.iEOS: {
-			return <Img src={iEOSIcon} {...props} />;
-		}
-		case Synths.iBNB: {
-			return <Img src={iBNBIcon} {...props} />;
-		}
-		case Synths.iXTZ: {
-			return <Img src={iXTZIcon} {...props} />;
-		}
-		case Synths.iXMR: {
-			return <Img src={iXMRIcon} {...props} />;
-		}
-		case Synths.iADA: {
-			return <Img src={iADAIcon} {...props} />;
-		}
-		case Synths.iLINK: {
-			return <Img src={iLINKIcon} {...props} />;
-		}
-		case Synths.iTRX: {
-			return <Img src={iTRXIcon} {...props} />;
-		}
-		case Synths.iDASH: {
-			return <Img src={iDASHIcon} {...props} />;
-		}
-		case Synths.iETC: {
-			return <Img src={iETCIcon} {...props} />;
-		}
-		case Synths.sTSLA: {
-			return <Img src={sTSLAIcon} {...props} />;
-		}
-		case Synths.sEUR: {
-			return <Img src={sEURIcon} {...props} />;
-		}
-		case Synths.sJPY: {
-			return <Img src={sJPYIcon} {...props} />;
-		}
-		case Synths.sUSD: {
-			return <Img src={sUSDIcon} {...props} />;
-		}
-		case Synths.sAUD: {
-			return <Img src={sAUDIcon} {...props} />;
-		}
-		case Synths.sGBP: {
-			return <Img src={sGBPIcon} {...props} />;
-		}
-		case Synths.sCHF: {
-			return <Img src={sCHFIcon} {...props} />;
-		}
-		case Synths.sXAU: {
-			return <Img src={sXAUIcon} {...props} />;
-		}
-		case Synths.sXAG: {
-			return <Img src={sXAGIcon} {...props} />;
-		}
-		case Synths.sCEX: {
-			return <Img src={sCEXIcon} {...props} />;
-		}
-		case Synths.sDEFI: {
-			return <Img src={sDEFIIcon} {...props} />;
-		}
-		case Synths.iCEX: {
-			return <Img src={iCEXIcon} {...props} />;
-		}
-		case Synths.iDEFI: {
-			return <Img src={iDEFIIcon} {...props} />;
-		}
-		case Synths.sFTSE: {
-			return <Img src={sFTSEIcon} {...props} />;
-		}
-		case Synths.sNIKKEI: {
-			return <Img src={sNIKKEIIcon} {...props} />;
-		}
-		case Synths.sOIL: {
-			return <Img src={sOILIcon} {...props} />;
-		}
-		case Synths.iOIL: {
-			return <Img src={iOILIcon} {...props} />;
-		}
-		case LP.BALANCER_sTSLA: {
-			return <Img src={sTSLAIcon} {...props} />;
-		}
-		case LP.BALANCER_sFB: {
-			return <Img src={sFBIcon} {...props} />;
-		}
-		case LP.BALANCER_sAAPL: {
-			return <Img src={sAAPLIcon} {...props} />;
-		}
-		case LP.BALANCER_sAMZN: {
-			return <Img src={sAMZNIcon} {...props} />;
-		}
-		case LP.BALANCER_sNFLX: {
-			return <Img src={sNFLXIcon} {...props} />;
-		}
-		case LP.BALANCER_sGOOG: {
-			return <Img src={sGOOGIcon} {...props} />;
-		}
-		case LP.CURVE_sUSD: {
-			return <Img src={sUSDIcon} {...props} />;
-		}
-		case LP.CURVE_sEURO: {
-			return <Img src={sEURIcon} {...props} />;
-		}
-		case LP.UNISWAP_DHT: {
-			return <Img src={DHTIcon} {...props} />;
-		}
-		default:
-			return null;
 	}
 };
+
+// 		case LP.BALANCER_sTSLA: {
+// 			return <Img src={sTSLAIcon} {...props} />;
+// 		}
+// 		case LP.BALANCER_sFB: {
+// 			return <Img src={sFBIcon} {...props} />;
+// 		}
+// 		case LP.BALANCER_sAAPL: {
+// 			return <Img src={sAAPLIcon} {...props} />;
+// 		}
+// 		case LP.BALANCER_sAMZN: {
+// 			return <Img src={sAMZNIcon} {...props} />;
+// 		}
+// 		case LP.BALANCER_sNFLX: {
+// 			return <Img src={sNFLXIcon} {...props} />;
+// 		}
+// 		case LP.BALANCER_sGOOG: {
+// 			return <Img src={sGOOGIcon} {...props} />;
+// 		}
+// 		case LP.CURVE_sUSD: {
+// 			return <Img src={sUSDIcon} {...props} />;
+// 		}
+// 		case LP.CURVE_sEURO: {
+// 			return <Img src={sEURIcon} {...props} />;
+// 		}
+// 		case LP.UNISWAP_DHT: {
+// 			return <Img src={DHTIcon} {...props} />;
+// 		}
+// 		default:
+// 			return null;
+// 	}
+// };
+
+const Placeholder = styled(FlexDivCentered)`
+	border-radius: 100%;
+	color: ${(props) => props.theme.colors.white};
+	border: 1px solid ${(props) => props.theme.colors.white};
+	font-size: 7px;
+	font-family: ${(props) => props.theme.fonts.interBold};
+	justify-content: center;
+	margin: 0 auto;
+`;
+
+const ZapperTokenIcon = styled.img`
+	border-radius: 100%;
+`;
 
 export default CurrencyIcon;

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -24,7 +24,7 @@ const ProgressBar: FC<ProgressBarProps> = ({ percentage, variant, ...rest }) => 
 
 	return (
 		<ProgressBarWrapper variant={variant} {...rest}>
-			{percentage <= 0 && <Bar className="filled-bar" percentage={100} />}
+			{percentage <= 0 && <Bar className="filled-bar" percentage={1000} />}
 			{percentage > 0 && <Bar className="filled-bar" percentage={Math.min(1, percentage)} />}
 			{unfilledPercentage > 0 && <Bar className="unfilled-bar" percentage={unfilledPercentage} />}
 		</ProgressBarWrapper>

--- a/constants/currency.ts
+++ b/constants/currency.ts
@@ -89,4 +89,6 @@ export const FIAT_SYNTHS = new Set([
 	Synths.sCHF,
 ]);
 
+export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
 export const sUSD_EXCHANGE_RATE = 1;

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -21,4 +21,8 @@ export const EXTERNAL_LINKS = {
 		Discord: 'https://discordapp.com/invite/AEdUHzt',
 		GitHub: 'https://github.com/synthetixio/staking',
 	},
+	TokenLists: {
+		Synthetix: 'https://synths.snx.eth.link',
+		Zapper: 'https://zapper.fi/api/token-list',
+	},
 };

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -269,6 +269,10 @@ export const QUERY_KEYS = {
 		],
 		Proposal: (spaceKey: SPACE_KEY, hash: string) => ['gov', 'proposal', spaceKey, hash],
 	},
+	TokenLists: {
+		Synthetix: ['tokenLists', 'synthetix'],
+		Zapper: ['tokenLists', 'zapper'],
+	},
 };
 
 export default QUERY_KEYS;

--- a/queries/1inch/use1InchQuoteQuery.ts
+++ b/queries/1inch/use1InchQuoteQuery.ts
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import QUERY_KEYS from 'constants/queryKeys';
 
-import { isWalletConnectedState, networkState, walletAddressState } from 'store/wallet';
+import { isL2State, isWalletConnectedState, networkState, walletAddressState } from 'store/wallet';
 import { appReadyState } from 'store/app';
 import { NumericValue, toBigNumber } from 'utils/formatters/number';
 import { formatEther, parseEther } from 'ethers/lib/utils';
@@ -24,6 +24,8 @@ const use1InchQuoteQuery = (
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
+	const isL2 = useRecoilValue(isL2State);
+
 	return useQuery<QuoteData>(
 		QUERY_KEYS.Swap.quote1Inch(walletAddress ?? '', network?.id!, amount),
 		async () => {
@@ -43,6 +45,7 @@ const use1InchQuoteQuery = (
 			enabled:
 				isAppReady &&
 				isWalletConnected &&
+				!isL2 &&
 				!toBigNumber(amount).isZero() &&
 				toBigNumber(amount).isPositive(),
 			...options,

--- a/queries/1inch/use1InchSwapQuery.ts
+++ b/queries/1inch/use1InchSwapQuery.ts
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import QUERY_KEYS from 'constants/queryKeys';
 
-import { isWalletConnectedState, networkState, walletAddressState } from 'store/wallet';
+import { isL2State, isWalletConnectedState, networkState, walletAddressState } from 'store/wallet';
 import { appReadyState } from 'store/app';
 import { NumericValue, toBigNumber } from 'utils/formatters/number';
 import { parseEther } from 'ethers/lib/utils';
@@ -32,6 +32,7 @@ const use1InchSwapQuery = (
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
+	const isL2 = useRecoilValue(isL2State);
 
 	return useQuery<SwapTxData>(
 		QUERY_KEYS.Swap.swap1Inch(walletAddress ?? '', network?.id!, amount, fromAddress),
@@ -54,7 +55,7 @@ const use1InchSwapQuery = (
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected && !toBigNumber(amount).isZero(),
+			enabled: isAppReady && isWalletConnected && !isL2 && !toBigNumber(amount).isZero(),
 			...options,
 		}
 	);

--- a/queries/tokenLists/types.ts
+++ b/queries/tokenLists/types.ts
@@ -1,0 +1,27 @@
+import { CurrencyKey } from 'constants/currency';
+
+export type Token = {
+	address: string;
+	chainId: number;
+	decimals: number;
+	logoURI: string;
+	name: string;
+	symbol: string;
+	tags: string[];
+};
+
+export type TokenListResponse = {
+	keywords: string[];
+	logoURI: string;
+	name: string;
+	tags: any;
+	timestamp: string;
+	tokens: Token[];
+	version: { major: number; minor: number; patch: number };
+};
+
+export type TokenListQueryResponse = {
+	tokens: Token[];
+	tokensMap: Record<CurrencyKey, Token>;
+	symbols: CurrencyKey[];
+};

--- a/queries/tokenLists/useSynthetixTokenList.ts
+++ b/queries/tokenLists/useSynthetixTokenList.ts
@@ -1,0 +1,31 @@
+import { useQuery, QueryConfig } from 'react-query';
+import axios from 'axios';
+import keyBy from 'lodash/keyBy';
+
+import QUERY_KEYS from 'constants/queryKeys';
+
+import { TokenListQueryResponse, TokenListResponse } from './types';
+import { EXTERNAL_LINKS } from 'constants/links';
+
+const useSynthetixTokenList = (options?: QueryConfig<TokenListQueryResponse>) => {
+	return useQuery<TokenListQueryResponse>(
+		QUERY_KEYS.TokenLists.Synthetix,
+		async () => {
+			const response = await axios.get<TokenListResponse>(EXTERNAL_LINKS.TokenLists.Synthetix);
+
+			return {
+				tokens: response.data.tokens,
+				tokensMap: keyBy(response.data.tokens, 'symbol'),
+				symbols: response.data.tokens.map((token) => token.symbol),
+			};
+		},
+		{
+			refetchInterval: false,
+			refetchOnWindowFocus: false,
+			refetchOnMount: false,
+			...options,
+		}
+	);
+};
+
+export default useSynthetixTokenList;

--- a/queries/tokenLists/useZapperTokenList.ts
+++ b/queries/tokenLists/useZapperTokenList.ts
@@ -1,0 +1,46 @@
+import { useQuery, QueryConfig } from 'react-query';
+import axios from 'axios';
+import keyBy from 'lodash/keyBy';
+
+import QUERY_KEYS from 'constants/queryKeys';
+import { CryptoCurrency, ETH_ADDRESS } from 'constants/currency';
+
+import ETHIcon from 'assets/svg/currencies/crypto/ETH.svg';
+
+import { TokenListQueryResponse, TokenListResponse } from './types';
+import { EXTERNAL_LINKS } from 'constants/links';
+
+const ether = {
+	address: ETH_ADDRESS,
+	chainId: 1,
+	decimals: 18,
+	logoURI: ETHIcon.src,
+	name: 'Ethereum',
+	symbol: CryptoCurrency.ETH,
+	tags: [],
+};
+
+const useZapperTokenList = (options?: QueryConfig<TokenListQueryResponse>) => {
+	return useQuery<TokenListQueryResponse>(
+		QUERY_KEYS.TokenLists.Zapper,
+		async () => {
+			const response = await axios.get<TokenListResponse>(EXTERNAL_LINKS.TokenLists.Zapper);
+
+			const tokens = [ether, ...response.data.tokens];
+
+			return {
+				tokens,
+				tokensMap: keyBy(tokens, 'symbol'),
+				symbols: tokens.map((token) => token.symbol),
+			};
+		},
+		{
+			refetchInterval: false,
+			refetchOnWindowFocus: false,
+			refetchOnMount: false,
+			...options,
+		}
+	);
+};
+
+export default useZapperTokenList;

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
@@ -20,6 +20,7 @@ import useUserStakingData from 'hooks/useUserStakingData';
 import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
 import { LP } from 'sections/earn/types';
 import useShortRewardsData from 'hooks/useShortRewardsData';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 
 const LayoutLayerOne: FC = () => {
 	const { t } = useTranslation();
@@ -126,7 +127,12 @@ const LayoutLayerOne: FC = () => {
 				gridLocations: ['col-1', 'col-2', 'row-3', 'row-4'],
 				icon: (
 					<GlowingCircle variant="green" size="md">
-						<Currency.Icon currencyKey={CryptoCurrency.CRV} width="28" height="28" />
+						<Currency.Icon
+							currencyKey={CryptoCurrency.CRV}
+							type={CurrencyIconType.TOKEN}
+							width="28"
+							height="28"
+						/>
 					</GlowingCircle>
 				),
 				title: t('dashboard.actions.earn.title', {
@@ -144,7 +150,12 @@ const LayoutLayerOne: FC = () => {
 				gridLocations: ['col-2', 'col-3', 'row-3', 'row-4'],
 				icon: (
 					<GlowingCircle variant="green" size="md">
-						<Currency.Icon currencyKey={LP.UNISWAP_DHT} width="28" height="28" />
+						<Currency.Icon
+							currencyKey={CryptoCurrency.DHT}
+							type={CurrencyIconType.TOKEN}
+							width="28"
+							height="28"
+						/>
 					</GlowingCircle>
 				),
 				title: t('dashboard.actions.earn.title', {
@@ -161,18 +172,86 @@ const LayoutLayerOne: FC = () => {
 				gridLocations: ['col-3', 'col-4', 'row-3', 'row-4'],
 				icon: (
 					<GlowingCircle variant="green" size="md">
-						<Currency.Icon currencyKey={Synths.sTSLA} width="28" height="28" />
+						<Currency.Icon currencyKey={Synths.sAAPL} width="28" height="28" />
 					</GlowingCircle>
 				),
 				title: t('dashboard.actions.earn.title', {
-					percent: formatPercent(lpData[LP.BALANCER_sTSLA].APR, { minDecimals: 0 }),
+					percent: formatPercent(lpData[LP.BALANCER_sAAPL].APR, { minDecimals: 0 }),
 				}),
 				copy: t('dashboard.actions.earn.copy', {
-					asset: 'Balancer sTSLA Pool Token',
+					asset: 'Balancer sAAPL Pool Token',
 					supplier: 'Synthetix',
 				}),
-				link: ROUTES.Earn.sTLSA_LP,
-				isDisabled: lpData[LP.BALANCER_sTSLA].APR === 0,
+				link: ROUTES.Earn.sAAPL_LP,
+				isDisabled: lpData[LP.BALANCER_sAAPL].APR === 0,
+			},
+			{
+				gridLocations: ['col-4', 'col-5', 'row-3', 'row-4'],
+				icon: (
+					<GlowingCircle variant="green" size="md">
+						<Currency.Icon currencyKey={Synths.sAMZN} width="28" height="28" />
+					</GlowingCircle>
+				),
+				title: t('dashboard.actions.earn.title', {
+					percent: formatPercent(lpData[LP.BALANCER_sAMZN].APR, { minDecimals: 0 }),
+				}),
+				copy: t('dashboard.actions.earn.copy', {
+					asset: 'Balancer sAMZN Pool Token',
+					supplier: 'Synthetix',
+				}),
+				link: ROUTES.Earn.sAMZN_LP,
+				isDisabled: lpData[LP.BALANCER_sAMZN].APR === 0,
+			},
+			{
+				gridLocations: ['col-1', 'col-2', 'row-4', 'row-5'],
+				icon: (
+					<GlowingCircle variant="green" size="md">
+						<Currency.Icon currencyKey={Synths.sFB} width="28" height="28" />
+					</GlowingCircle>
+				),
+				title: t('dashboard.actions.earn.title', {
+					percent: formatPercent(lpData[LP.BALANCER_sFB].APR, { minDecimals: 0 }),
+				}),
+				copy: t('dashboard.actions.earn.copy', {
+					asset: 'Balancer sFB Pool Token',
+					supplier: 'Synthetix',
+				}),
+				link: ROUTES.Earn.sFB_LP,
+				isDisabled: lpData[LP.BALANCER_sFB].APR === 0,
+			},
+			{
+				gridLocations: ['col-2', 'col-3', 'row-4', 'row-5'],
+				icon: (
+					<GlowingCircle variant="green" size="md">
+						<Currency.Icon currencyKey={Synths.sGOOG} width="28" height="28" />
+					</GlowingCircle>
+				),
+				title: t('dashboard.actions.earn.title', {
+					percent: formatPercent(lpData[LP.BALANCER_sGOOG].APR, { minDecimals: 0 }),
+				}),
+				copy: t('dashboard.actions.earn.copy', {
+					asset: 'Balancer sGOOG Pool Token',
+					supplier: 'Synthetix',
+				}),
+				link: ROUTES.Earn.sGOOG_LP,
+				isDisabled: lpData[LP.BALANCER_sGOOG].APR === 0,
+			},
+			{
+				gridLocations: ['col-3', 'col-4', 'row-4', 'row-5'],
+				icon: (
+					<GlowingCircle variant="green" size="md">
+						<Currency.Icon currencyKey={Synths.sNFLX} width="28" height="28" />
+					</GlowingCircle>
+				),
+				title: t('dashboard.actions.earn.title', {
+					percent: formatPercent(lpData[LP.BALANCER_sNFLX].APR, { minDecimals: 0 }),
+				}),
+				copy: t('dashboard.actions.earn.copy', {
+					asset: 'Balancer sNFLX Pool Token',
+					supplier: 'Synthetix',
+				}),
+				link: ROUTES.Earn.sNFLX_LP,
+				isDisabled: lpData[LP.BALANCER_sNFLX].APR === 0,
 			},
 		];
 	}, [t, lpData, currentCRatio, targetCRatio, stakingRewards, tradingRewards, shortData]);

--- a/sections/earn/IncentivesDefault.tsx
+++ b/sections/earn/IncentivesDefault.tsx
@@ -70,6 +70,7 @@ const Incentives: FC<IncentivesProps> = ({
 							staked: {
 								balance: stakedAmount,
 								asset: CryptoCurrency.SNX,
+								ticker: CryptoCurrency.SNX,
 							},
 							rewards: stakingRewards.toNumber(),
 							periodStarted: currentFeePeriodStarted.getTime(),

--- a/sections/earn/IncentivesMainnet.tsx
+++ b/sections/earn/IncentivesMainnet.tsx
@@ -18,10 +18,11 @@ import ClaimTab from './ClaimTab';
 import LPTab from './LPTab';
 import { isWalletConnectedState } from 'store/wallet';
 
-import { Tab, LP, lpToTab, tabToLP, lpToSynthTranslationKey } from './types';
+import { Tab, LP, lpToTab, tabToLP, lpToSynthTranslationKey, lpToSynthIcon } from './types';
 import { zeroBN } from 'utils/formatters/number';
 import useShortRewardsData from 'hooks/useShortRewardsData';
 import { TabButton, TabList } from 'components/Tab';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 
 enum View {
 	ACTIVE = 'active',
@@ -79,11 +80,13 @@ const Incentives: FC<IncentivesProps> = ({
 				[LP.BALANCER_sAMZN]: ROUTES.Earn.sAMZN_LP,
 				[LP.BALANCER_sNFLX]: ROUTES.Earn.sNFLX_LP,
 				[LP.BALANCER_sGOOG]: ROUTES.Earn.sGOOG_LP,
+				[LP.BALANCER_sTSLA]: ROUTES.Earn.sTLSA_LP,
 			};
 
 			const tab = lpToTab[balancerLP];
 			const synthTransKey = lpToSynthTranslationKey[balancerLP];
 			const route = lpToRoute[balancerLP];
+			const currencyKey = lpToSynthIcon[balancerLP];
 
 			return {
 				title: t(`earn.incentives.options.${synthTransKey}.title`),
@@ -92,7 +95,8 @@ const Incentives: FC<IncentivesProps> = ({
 				tvl: lpData[balancerLP].TVL,
 				staked: {
 					balance: lpData[balancerLP].data?.staked ?? 0,
-					asset: balancerLP,
+					asset: currencyKey,
+					ticker: balancerLP,
 				},
 				rewards: lpData[balancerLP].data?.rewards ?? 0,
 				periodStarted: now - (lpData[balancerLP].data?.duration ?? 0),
@@ -114,6 +118,7 @@ const Incentives: FC<IncentivesProps> = ({
 						staked: {
 							balance: stakedAmount,
 							asset: CryptoCurrency.SNX,
+							ticker: CryptoCurrency.SNX,
 						},
 						rewards: stakingRewards.toNumber(),
 						periodStarted: currentFeePeriodStarted.getTime(),
@@ -131,6 +136,7 @@ const Incentives: FC<IncentivesProps> = ({
 						staked: {
 							balance: lpData[Synths.iETH].data?.staked ?? 0,
 							asset: Synths.iETH,
+							ticker: Synths.iETH,
 						},
 						rewards: lpData[Synths.iETH].data?.rewards ?? 0,
 						periodStarted: now - (lpData[Synths.iETH].data?.duration ?? 0),
@@ -142,6 +148,25 @@ const Incentives: FC<IncentivesProps> = ({
 						needsToSettle: lpData[Synths.iETH].data?.needsToSettle,
 					},
 					{
+						title: t('earn.incentives.options.ibtc.title'),
+						subtitle: t('earn.incentives.options.ibtc.subtitle'),
+						apr: lpData[Synths.iBTC].APR,
+						tvl: lpData[Synths.iBTC].TVL,
+						staked: {
+							balance: lpData[Synths.iBTC].data?.staked ?? 0,
+							asset: Synths.iBTC,
+							ticker: Synths.iBTC,
+						},
+						rewards: lpData[Synths.iBTC].data?.rewards ?? 0,
+						periodStarted: now - (lpData[Synths.iBTC].data?.duration ?? 0),
+						periodFinish: lpData[Synths.iBTC].data?.periodFinish ?? 0,
+						claimed: (lpData[Synths.iBTC].data?.rewards ?? 0) > 0 ? false : NOT_APPLICABLE,
+						now,
+						tab: Tab.iBTC_LP,
+						route: ROUTES.Earn.iBTC_LP,
+						needsToSettle: lpData[Synths.iBTC].data?.needsToSettle,
+					},
+					{
 						title: t('earn.incentives.options.sbtc.title'),
 						subtitle: t('earn.incentives.options.sbtc.subtitle'),
 						apr: shortData[Synths.sBTC].APR,
@@ -149,6 +174,7 @@ const Incentives: FC<IncentivesProps> = ({
 						staked: {
 							balance: shortData[Synths.sBTC].data?.staked ?? 0,
 							asset: Synths.sBTC,
+							ticker: Synths.sBTC,
 						},
 						rewards: shortData[Synths.sBTC].data?.rewards ?? 0,
 						periodStarted: now - (shortData[Synths.sBTC].data?.duration ?? 0),
@@ -167,6 +193,7 @@ const Incentives: FC<IncentivesProps> = ({
 						staked: {
 							balance: shortData[Synths.sETH].data?.staked ?? 0,
 							asset: Synths.sETH,
+							ticker: Synths.sETH,
 						},
 						rewards: shortData[Synths.sETH].data?.rewards ?? 0,
 						periodStarted: now - (shortData[Synths.sETH].data?.duration ?? 0),
@@ -177,29 +204,13 @@ const Incentives: FC<IncentivesProps> = ({
 						route: ROUTES.Earn.sETH_SHORT,
 						externalLink: ROUTES.Earn.sETH_EXTERNAL,
 					},
-					{
-						title: t('earn.incentives.options.stsla.title'),
-						subtitle: t('earn.incentives.options.stsla.subtitle'),
-						apr: lpData[LP.BALANCER_sTSLA].APR,
-						tvl: lpData[LP.BALANCER_sTSLA].TVL,
-						staked: {
-							balance: lpData[LP.BALANCER_sTSLA].data?.staked ?? 0,
-							asset: LP.BALANCER_sTSLA,
-						},
-						rewards: lpData[LP.BALANCER_sTSLA].data?.rewards ?? 0,
-						periodStarted: now - (lpData[LP.BALANCER_sTSLA].data?.duration ?? 0),
-						periodFinish: lpData[LP.BALANCER_sTSLA].data?.periodFinish ?? 0,
-						claimed: (lpData[LP.BALANCER_sTSLA].data?.rewards ?? 0) > 0 ? false : NOT_APPLICABLE,
-						now,
-						route: ROUTES.Earn.sTLSA_LP,
-						tab: Tab.sTLSA_LP,
-					},
 					...[
 						LP.BALANCER_sFB,
 						LP.BALANCER_sAAPL,
 						LP.BALANCER_sAMZN,
 						LP.BALANCER_sNFLX,
 						LP.BALANCER_sGOOG,
+						LP.BALANCER_sTSLA,
 					].map(balancerIncentives),
 					{
 						title: t('earn.incentives.options.curve.title'),
@@ -208,7 +219,9 @@ const Incentives: FC<IncentivesProps> = ({
 						tvl: lpData[LP.CURVE_sUSD].TVL,
 						staked: {
 							balance: lpData[LP.CURVE_sUSD].data?.staked ?? 0,
-							asset: LP.CURVE_sUSD,
+							asset: CryptoCurrency.CRV,
+							ticker: LP.CURVE_sUSD,
+							type: CurrencyIconType.TOKEN,
 						},
 						rewards: lpData[LP.CURVE_sUSD].data?.rewards ?? 0,
 						periodStarted: now - (lpData[LP.CURVE_sUSD].data?.duration ?? 0),
@@ -226,7 +239,9 @@ const Incentives: FC<IncentivesProps> = ({
 						tvl: lpData[LP.UNISWAP_DHT].TVL,
 						staked: {
 							balance: lpData[LP.UNISWAP_DHT].data?.staked ?? 0,
-							asset: LP.UNISWAP_DHT,
+							asset: CryptoCurrency.DHT,
+							ticker: LP.UNISWAP_DHT,
+							type: CurrencyIconType.TOKEN,
 						},
 						rewards: lpData[LP.UNISWAP_DHT].data?.rewards ?? 0,
 						periodStarted: now - (lpData[LP.UNISWAP_DHT].data?.duration ?? 0),
@@ -239,24 +254,6 @@ const Incentives: FC<IncentivesProps> = ({
 						now,
 						route: ROUTES.Earn.DHT_LP,
 						tab: Tab.DHT_LP,
-					},
-					{
-						title: t('earn.incentives.options.ibtc.title'),
-						subtitle: t('earn.incentives.options.ibtc.subtitle'),
-						apr: lpData[Synths.iBTC].APR,
-						tvl: lpData[Synths.iBTC].TVL,
-						staked: {
-							balance: lpData[Synths.iBTC].data?.staked ?? 0,
-							asset: Synths.iBTC,
-						},
-						rewards: lpData[Synths.iBTC].data?.rewards ?? 0,
-						periodStarted: now - (lpData[Synths.iBTC].data?.duration ?? 0),
-						periodFinish: lpData[Synths.iBTC].data?.periodFinish ?? 0,
-						claimed: (lpData[Synths.iBTC].data?.rewards ?? 0) > 0 ? false : NOT_APPLICABLE,
-						now,
-						tab: Tab.iBTC_LP,
-						route: ROUTES.Earn.iBTC_LP,
-						needsToSettle: lpData[Synths.iBTC].data?.needsToSettle,
 					},
 			  ]
 			: [];
@@ -299,6 +296,7 @@ const Incentives: FC<IncentivesProps> = ({
 
 	const balancerTab = (selectedTab: Tab) => {
 		const lp = tabToLP[selectedTab];
+		const currencyKey = lpToSynthIcon[lp];
 
 		return (
 			activeTab === selectedTab && (
@@ -307,6 +305,7 @@ const Incentives: FC<IncentivesProps> = ({
 					userBalance={lpData[lp].data?.userBalance ?? 0}
 					userBalanceBN={lpData[lp].data?.userBalanceBN ?? zeroBN}
 					stakedAsset={lp}
+					icon={currencyKey}
 					allowance={lpData[lp].data?.allowance ?? null}
 					tokenRewards={lpData[lp].data?.rewards ?? 0}
 					staked={lpData[lp].data?.staked ?? 0}
@@ -376,24 +375,29 @@ const Incentives: FC<IncentivesProps> = ({
 						needsToSettle={lpData[Synths.iETH].data?.needsToSettle}
 					/>
 				)}
-				{activeTab === Tab.sTLSA_LP && (
+				{/* {activeTab === Tab.sTLSA_LP && (
 					<LPTab
 						userBalance={lpData[LP.BALANCER_sTSLA].data?.userBalance ?? 0}
 						userBalanceBN={lpData[LP.BALANCER_sTSLA].data?.userBalanceBN ?? zeroBN}
 						stakedAsset={LP.BALANCER_sTSLA}
+						icon={Synths.sTSLA}
 						allowance={lpData[LP.BALANCER_sTSLA].data?.allowance ?? null}
 						tokenRewards={lpData[LP.BALANCER_sTSLA].data?.rewards ?? 0}
 						staked={lpData[LP.BALANCER_sTSLA].data?.staked ?? 0}
 						stakedBN={lpData[LP.BALANCER_sTSLA].data?.stakedBN ?? zeroBN}
 						needsToSettle={lpData[LP.BALANCER_sTSLA].data?.needsToSettle}
 					/>
+				)} */}
+				{[Tab.sFB_LP, Tab.sAAPL_LP, Tab.sAMZN_LP, Tab.sNFLX_LP, Tab.sGOOG_LP, Tab.sTLSA_LP].map(
+					balancerTab
 				)}
-				{[Tab.sFB_LP, Tab.sAAPL_LP, Tab.sAMZN_LP, Tab.sNFLX_LP, Tab.sGOOG_LP].map(balancerTab)}
 				{activeTab === Tab.DHT_LP && (
 					<LPTab
 						userBalance={lpData[LP.UNISWAP_DHT].data?.userBalance ?? 0}
 						userBalanceBN={lpData[LP.UNISWAP_DHT].data?.userBalanceBN ?? zeroBN}
 						stakedAsset={LP.UNISWAP_DHT}
+						icon={CryptoCurrency.DHT}
+						type={CurrencyIconType.TOKEN}
 						allowance={lpData[LP.UNISWAP_DHT].data?.allowance ?? null}
 						tokenRewards={lpData[LP.UNISWAP_DHT].data?.rewards ?? 0}
 						staked={lpData[LP.UNISWAP_DHT].data?.staked ?? 0}

--- a/sections/earn/IncentivesTable.tsx
+++ b/sections/earn/IncentivesTable.tsx
@@ -41,6 +41,7 @@ import { DURATION_SEPARATOR } from 'constants/date';
 import ROUTES from 'constants/routes';
 
 import { LP, Tab } from './types';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 
 export type DualRewards = {
 	a: number;
@@ -57,6 +58,8 @@ export type EarnItem = {
 	staked: {
 		balance: number;
 		asset: CurrencyKey;
+		ticker: CurrencyKey;
+		type?: CurrencyIconType;
 	};
 	rewards: number | DualRewards;
 	periodStarted: number;
@@ -96,7 +99,15 @@ const IncentivesTable: FC<IncentivesTableProps> = ({ data, isLoaded, activeTab }
 					return (
 						<>
 							<StyledGlowingCircle variant="green" size="sm">
-								<Currency.Icon currencyKey={cellProps.row.original.staked.asset} {...iconProps} />
+								<Currency.Icon
+									currencyKey={cellProps.row.original.staked.asset}
+									type={
+										cellProps.row.original.staked.type
+											? cellProps.row.original.staked.type
+											: undefined
+									}
+									{...iconProps}
+								/>
 							</StyledGlowingCircle>
 							<FlexDivCol>
 								<Title>{cellProps.row.original.title}</Title>
@@ -140,10 +151,10 @@ const IncentivesTable: FC<IncentivesTableProps> = ({ data, isLoaded, activeTab }
 					<CellContainer>
 						<Title isNumeric={true}>
 							{formatCurrency(
-								cellProps.row.original.staked.asset,
+								cellProps.row.original.staked.ticker,
 								cellProps.row.original.staked.balance,
 								{
-									currencyKey: cellProps.row.original.staked.asset,
+									currencyKey: cellProps.row.original.staked.ticker,
 								}
 							)}
 						</Title>

--- a/sections/earn/LPTab/LPTab.tsx
+++ b/sections/earn/LPTab/LPTab.tsx
@@ -48,6 +48,7 @@ import {
 
 import { LP, lpToSynthTranslationKey } from 'sections/earn/types';
 import styled from 'styled-components';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 
 type DualRewards = {
 	a: number;
@@ -56,6 +57,8 @@ type DualRewards = {
 
 type LPTabProps = {
 	stakedAsset: CurrencyKey;
+	icon?: CurrencyKey;
+	type?: CurrencyIconType;
 	tokenRewards: number | DualRewards;
 	allowance: number | null;
 	userBalance: number;
@@ -68,6 +71,8 @@ type LPTabProps = {
 
 const LPTab: FC<LPTabProps> = ({
 	stakedAsset,
+	icon = stakedAsset,
+	type,
 	tokenRewards,
 	allowance,
 	userBalance,
@@ -109,6 +114,8 @@ const LPTab: FC<LPTabProps> = ({
 			userBalanceBN,
 			staked,
 			stakedBN,
+			icon,
+			type,
 		};
 
 		return [
@@ -357,6 +364,8 @@ const LPTab: FC<LPTabProps> = ({
 						claimError={claimError}
 						setClaimError={setClaimError}
 						stakedAsset={stakedAsset}
+						icon={icon}
+						type={type}
 						tokenRewards={(tokenRewards as DualRewards).a}
 						SNXRate={SNXRate}
 						secondTokenReward={(tokenRewards as DualRewards).b}
@@ -382,6 +391,8 @@ const LPTab: FC<LPTabProps> = ({
 						claimError={claimError}
 						setClaimError={setClaimError}
 						stakedAsset={stakedAsset}
+						icon={icon}
+						type={type}
 						tokenRewards={tokenRewards as number}
 						SNXRate={SNXRate}
 					/>

--- a/sections/earn/LPTab/RewardsBox/RewardsBox.tsx
+++ b/sections/earn/LPTab/RewardsBox/RewardsBox.tsx
@@ -34,11 +34,14 @@ import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
 
 import { getContract } from '../StakeTab/StakeTab';
 import { StyledButton } from '../../common';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 
 type RewardsBoxProps = {
 	tokenRewards: number;
 	SNXRate: number;
 	stakedAsset: CurrencyKey;
+	icon: CurrencyKey;
+	type?: CurrencyIconType;
 	handleClaim: () => void;
 	setClaimGasPrice: (num: number) => void;
 	claimTxModalOpen: boolean;
@@ -54,6 +57,8 @@ const RewardsBox: FC<RewardsBoxProps> = ({
 	tokenRewards,
 	SNXRate,
 	stakedAsset,
+	icon,
+	type,
 	handleClaim,
 	setClaimGasPrice,
 	claimTxModalOpen,
@@ -114,7 +119,12 @@ const RewardsBox: FC<RewardsBoxProps> = ({
 					</FlexDivColCentered>
 					{isDualRewards && secondTokenKey && (
 						<FlexDivColCentered>
-							<Currency.Icon currencyKey={stakedAsset} width="48" height="48" />
+							<Currency.Icon
+								currencyKey={icon}
+								type={type ? type : undefined}
+								width="48"
+								height="48"
+							/>
 							<RewardsAmountSNX>
 								{formatCurrency(secondTokenKey, secondTokenReward!, {
 									currencyKey: secondTokenKey,

--- a/sections/earn/LPTab/StakeTab/StakeTab.tsx
+++ b/sections/earn/LPTab/StakeTab/StakeTab.tsx
@@ -52,6 +52,7 @@ import { useRecoilValue } from 'recoil';
 import { appReadyState } from 'store/app';
 import curveSeuroRewards from 'contracts/curveSeuroRewards';
 import { LP } from 'sections/earn/types';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 
 export const getContract = (stakedAsset: CurrencyKey, signer: ethers.Signer | null) => {
 	const { contracts } = synthetix.js!;
@@ -97,6 +98,8 @@ export const getContract = (stakedAsset: CurrencyKey, signer: ethers.Signer | nu
 type StakeTabProps = {
 	isStake: boolean;
 	stakedAsset: CurrencyKey;
+	icon: CurrencyKey;
+	type?: CurrencyIconType;
 	userBalance: number;
 	userBalanceBN: BigNumber;
 	staked: number;
@@ -105,6 +108,8 @@ type StakeTabProps = {
 
 const StakeTab: FC<StakeTabProps> = ({
 	stakedAsset,
+	icon,
+	type,
 	isStake,
 	userBalance,
 	userBalanceBN,
@@ -320,7 +325,12 @@ const StakeTab: FC<StakeTabProps> = ({
 		<>
 			<Container>
 				<IconWrap>
-					<Currency.Icon currencyKey={stakedAsset} width={'38'} height={'38'} />
+					<Currency.Icon
+						currencyKey={icon}
+						width={'38'}
+						height={'38'}
+						type={type ? type : undefined}
+					/>
 				</IconWrap>
 				<InputSection>
 					<EmptyDiv />

--- a/sections/earn/types.ts
+++ b/sections/earn/types.ts
@@ -1,3 +1,4 @@
+import { Synths } from 'constants/currency';
 import { invert } from 'lodash';
 
 export enum Tab {
@@ -45,4 +46,14 @@ export const lpToSynthTranslationKey: { [name: string]: string } = {
 	[LP.BALANCER_sAMZN]: 'samzn',
 	[LP.BALANCER_sNFLX]: 'snflx',
 	[LP.BALANCER_sGOOG]: 'sgoog',
+	[LP.BALANCER_sTSLA]: 'stsla',
+};
+
+export const lpToSynthIcon: { [name: string]: string } = {
+	[LP.BALANCER_sFB]: Synths.sFB,
+	[LP.BALANCER_sAAPL]: Synths.sAAPL,
+	[LP.BALANCER_sAMZN]: Synths.sAMZN,
+	[LP.BALANCER_sNFLX]: Synths.sNFLX,
+	[LP.BALANCER_sGOOG]: Synths.sGOOG,
+	[LP.BALANCER_sTSLA]: Synths.sTSLA,
 };


### PR DESCRIPTION
This PR aims to:
- Convert currency icon to use tokenlists and synthetix/assets as a fallback so that we can automatically get the latest currency assets deployed
- Adds the balancer incentives to the frontpage layout
- Disables 1inch queries on L2
- Fixes the progress bar when the timer has ended on incentives (makes it full rainbow width)
