### PR TITLE
fix: Clear Debt

### DIFF
--- a/sections/staking/components/BurnTab/BurnTab.tsx
+++ b/sections/staking/components/BurnTab/BurnTab.tsx
@@ -13,7 +13,7 @@ import BurnTiles from '../BurnTiles';
 import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
 import StakingInput from '../StakingInput';
 import { Transaction } from 'constants/network';
-import { formatCurrency, toBigNumber } from 'utils/formatters/number';
+import { formatCurrency, toBigNumber, zeroBN } from 'utils/formatters/number';
 import { amountToBurnState, BurnActionType, burnTypeState } from 'store/staking';
 import { addSeconds, differenceInSeconds } from 'date-fns';
 import useSynthsBalancesQuery from 'queries/walletBalances/useSynthsBalancesQuery';
@@ -25,6 +25,7 @@ import Connector from 'containers/Connector';
 import useClearDebtCalculations from 'sections/staking/hooks/useClearDebtCalculations';
 import { useTranslation } from 'react-i18next';
 import { toFutureDate } from 'utils/formatters/date';
+import useETHBalanceQuery from 'queries/walletBalances/useETHBalanceQuery';
 
 const BurnTab: React.FC = () => {
 	const { monitorTransaction } = TransactionNotifier.useContainer();
@@ -64,6 +65,9 @@ const BurnTab: React.FC = () => {
 		quoteAmount,
 		swapData,
 	} = useClearDebtCalculations(debtBalance, sUSDBalance, walletAddress!);
+
+	const ethBalanceQuery = useETHBalanceQuery();
+	const ethBalance = ethBalanceQuery.data ?? zeroBN;
 
 	const getMaxSecsLeftInWaitingPeriod = useCallback(async () => {
 		const {
@@ -132,6 +136,11 @@ const BurnTab: React.FC = () => {
 						burnType !== BurnActionType.CLEAR
 					)
 						throw new Error(t('staking.actions.burn.action.error.insufficient'));
+
+					if (toBigNumber(quoteAmount).isGreaterThan(ethBalance)) {
+						throw new Error(t('staking.actions.burn.action.error.insufficient-eth-1inch'));
+					}
+
 					if (waitingPeriod) {
 						throw new Error(
 							t('staking.actions.burn.action.error.waiting-period', {
@@ -179,6 +188,8 @@ const BurnTab: React.FC = () => {
 		sUSDBalance,
 		waitingPeriod,
 		burnType,
+		ethBalance,
+		quoteAmount,
 	]);
 
 	const handleBurn = useCallback(
@@ -342,7 +353,7 @@ const BurnTab: React.FC = () => {
 					isLocked = true;
 					break;
 				}
-				onBurnChange(debtBalance.toString());
+				onBurnChange(debtBalanceWithBuffer.toString());
 				handleSubmit = () => handleClear();
 				inputValue = toBigNumber(debtBalanceWithBuffer);
 				isLocked = true;

--- a/translations/en.json
+++ b/translations/en.json
@@ -294,6 +294,7 @@
 					"error": {
 						"no-debt": "No debt to burn",
 						"bad-input": "Invalid input amount",
+						"insufficient-eth-1inch": "Insufficient ETH to execute 1inch swap",
 						"waiting-period": "Burning blocked until {{date}}",
 						"issuance-period": "Burning blocked until {{date}}",
 						"insufficient": "Insufficient sUSD to burn debt",


### PR DESCRIPTION
- adds error state for not enough ETH in wallet
- also changes burn amount to === all sUSD in wallet (which is debtBalance + 1inch buffer) to account for possible debt shifts