### PR TITLE
set TotalPendingMigration to 0 if L2

### DIFF
--- a/queries/escrow/useEscrowDataQuery.tsx
+++ b/queries/escrow/useEscrowDataQuery.tsx
@@ -3,10 +3,11 @@ import { useRecoilValue } from 'recoil';
 import chunk from 'lodash/chunk';
 import synthetix from 'lib/synthetix';
 import { orderBy, flatten } from 'lodash';
+import { ethers } from 'ethers';
 
 import QUERY_KEYS from 'constants/queryKeys';
 
-import { isWalletConnectedState, networkState, walletAddressState } from 'store/wallet';
+import { isWalletConnectedState, networkState, walletAddressState, isL2State } from 'store/wallet';
 import { appReadyState } from 'store/app';
 
 const VESTING_ENTRIES_PAGINATION = 50;
@@ -40,6 +41,7 @@ const useEscrowDataQuery = (options?: QueryConfig<EscrowData>) => {
 	const walletAddress = useRecoilValue(walletAddressState);
 	const network = useRecoilValue(networkState);
 	const isAppReady = useRecoilValue(appReadyState);
+	const isL2 = useRecoilValue(isL2State);
 
 	return useQuery<EscrowData>(
 		QUERY_KEYS.Escrow.StakingRewards(walletAddress ?? '', network?.id!),
@@ -57,7 +59,9 @@ const useEscrowDataQuery = (options?: QueryConfig<EscrowData>) => {
 				RewardEscrowV2.numVestingEntries(walletAddress),
 				RewardEscrowV2.balanceOf(walletAddress),
 				RewardEscrowV2.totalVestedAccountBalance(walletAddress),
-				RewardEscrowV2.totalBalancePendingMigration(walletAddress),
+				isL2
+					? ethers.BigNumber.from(0)
+					: RewardEscrowV2.totalBalancePendingMigration(walletAddress),
 			]);
 
 			let vestingEntriesPromise = [];


### PR DESCRIPTION
Escrow screen is broken on L2 because `TotalPendingMigration()` doesn't exist.