### PR TITLE
Feat/liquidation banner

### DIFF
--- a/components/BannerManager/BannerManager.tsx
+++ b/components/BannerManager/BannerManager.tsx
@@ -22,7 +22,7 @@ const BannerManager: FC = () => {
 		? 0
 		: 100 / Number(ethersUtils.formatEther(liquidationRatio.toString()));
 
-	if (!liquidationDeadlineForAccount?.isZero()) {
+	if (!liquidationDeadlineForAccount.isZero()) {
 		return (
 			<Banner
 				type={BannerType.WARNING}

--- a/components/BannerManager/BannerManager.tsx
+++ b/components/BannerManager/BannerManager.tsx
@@ -1,0 +1,75 @@
+import { FC } from 'react';
+import { Trans } from 'react-i18next';
+import styled from 'styled-components';
+import { utils as ethersUtils } from 'ethers';
+
+import useGetLiquidationData from 'queries/liquidations/useGetLiquidationDataQuery';
+
+import Banner, { BannerType } from 'sections/shared/Layout/Banner';
+import { LOCAL_STORAGE_KEYS } from 'constants/storage';
+import { ExternalLink } from 'styles/common';
+import { zeroBN } from 'utils/formatters/number';
+import { formatShortDateWithTime } from 'utils/formatters/date';
+
+const BannerManager: FC = () => {
+	const liquidationData = useGetLiquidationData();
+
+	const liquidationRatio = liquidationData?.data?.liquidationRatio ?? zeroBN;
+	const liquidationDeadlineForAccount =
+		liquidationData?.data?.liquidationDeadlineForAccount ?? zeroBN;
+
+	const liquidationRatioPercentage = liquidationRatio.isZero()
+		? 0
+		: 100 / Number(ethersUtils.formatEther(liquidationRatio.toString()));
+
+	if (!liquidationDeadlineForAccount?.isZero()) {
+		return (
+			<Banner
+				type={BannerType.WARNING}
+				message={
+					<Trans
+						i18nKey={'user-menu.banner.liquidation-warning'}
+						values={{
+							liquidationRatio: liquidationRatioPercentage,
+							liquidationDeadline: formatShortDateWithTime(
+								Number(liquidationDeadlineForAccount.toString()) * 1000
+							),
+						}}
+						components={[
+							<Strong />,
+							<Strong />,
+							<StyledExternalLink href="https://blog.synthetix.io/liquidation-faqs" />,
+						]}
+					/>
+				}
+			/>
+		);
+	} else {
+		return (
+			<Banner
+				type={BannerType.ATTENTION}
+				localStorageKey={LOCAL_STORAGE_KEYS.WARNING_URL_BANNER_VISIBLE}
+				message={
+					<Trans
+						i18nKey={'user-menu.banner.url-warning'}
+						components={[<StyledExternalLink href="https://staking.synthetix.io" />]}
+					/>
+				}
+			/>
+		);
+	}
+};
+
+const Strong = styled.strong`
+	font-family: ${(props) => props.theme.fonts.condensedBold};
+`;
+
+const StyledExternalLink = styled(ExternalLink)`
+	color: ${(props) => props.theme.colors.white};
+	text-decoration: underline;
+	&:hover {
+		text-decoration: underline;
+	}
+`;
+
+export default BannerManager;

--- a/components/BannerManager/index.ts
+++ b/components/BannerManager/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BannerManager';

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -19,6 +19,14 @@ export const QUERY_KEYS = {
 			networkId,
 		],
 	},
+	Liquidations: {
+		LiquidationsData: (walletAddress: string, networkId: NetworkId) => [
+			'liquidations',
+			'liquidationsData',
+			walletAddress,
+			networkId,
+		],
+	},
 	Staking: {
 		FeePoolData: (period: string) => ['staking', 'feePoolData', period],
 		FeeClaimHistory: (walletAddress: string, networkId: NetworkId) => [

--- a/queries/liquidations/useGetLiquidationDataQuery.ts
+++ b/queries/liquidations/useGetLiquidationDataQuery.ts
@@ -1,0 +1,51 @@
+import { useQuery, QueryConfig } from 'react-query';
+import { useRecoilValue } from 'recoil';
+import BigNumber from 'bignumber.js';
+
+import synthetix from 'lib/synthetix';
+import { isWalletConnectedState, networkState, walletAddressState, isL2State } from 'store/wallet';
+import { appReadyState } from 'store/app';
+import QUERY_KEYS from 'constants/queryKeys';
+
+type LiquidationData = {
+	liquidationRatio: BigNumber;
+	liquidationDelay: BigNumber;
+	liquidationDeadlineForAccount: BigNumber;
+};
+
+const useGetLiquidationDataQuery = (options?: QueryConfig<LiquidationData>) => {
+	const isAppReady = useRecoilValue(appReadyState);
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+	const walletAddress = useRecoilValue(walletAddressState);
+	const network = useRecoilValue(networkState);
+	const isL2 = useRecoilValue(isL2State);
+
+	return useQuery<LiquidationData>(
+		QUERY_KEYS.Liquidations.LiquidationsData(walletAddress ?? '', network?.id!),
+		async () => {
+			const {
+				contracts: { Liquidations },
+			} = synthetix.js!;
+			const [
+				liquidationRatio,
+				liquidationDelay,
+				liquidationDeadlineForAccount,
+			] = await Promise.all([
+				Liquidations.liquidationRatio(),
+				Liquidations.liquidationDelay(),
+				Liquidations.getLiquidationDeadlineForAccount(walletAddress),
+			]);
+			return {
+				liquidationRatio,
+				liquidationDelay,
+				liquidationDeadlineForAccount,
+			};
+		},
+		{
+			enabled: isAppReady && isWalletConnected && !isL2,
+			...options,
+		}
+	);
+};
+
+export default useGetLiquidationDataQuery;

--- a/sections/shared/Layout/Banner/Banner.tsx
+++ b/sections/shared/Layout/Banner/Banner.tsx
@@ -15,20 +15,17 @@ export enum BannerType {
 type BannerProps = {
 	message: JSX.Element;
 	localStorageKey?: string | undefined;
-	topOffset?: number | undefined;
 	type?: BannerType;
 };
 
-const Banner: FC<BannerProps> = ({
-	message,
-	localStorageKey,
-	topOffset,
-	type = BannerType.INFORMATION,
-}) => {
+const Banner: FC<BannerProps> = ({ message, localStorageKey, type = BannerType.INFORMATION }) => {
 	const [isBannerVisible, setIsBannerVisible] = useState<boolean>(true);
 
 	const fetchFromLocalStorage = useCallback(() => {
-		if (!localStorageKey) return;
+		if (!localStorageKey) {
+			setIsBannerVisible(true);
+			return;
+		}
 		if (!localStorage.getItem(localStorageKey)) return;
 		setIsBannerVisible(localStorage.getItem(localStorageKey) === 'true');
 	}, [localStorageKey]);
@@ -45,7 +42,7 @@ const Banner: FC<BannerProps> = ({
 
 	if (!isBannerVisible) return null;
 	return (
-		<Container topOffset={topOffset}>
+		<Container>
 			<Inner>
 				<Bar type={type} />
 				<Message>{message}</Message>
@@ -60,7 +57,7 @@ const Banner: FC<BannerProps> = ({
 	);
 };
 
-const Container = styled(FlexDivCentered)<{ topOffset: number | undefined }>`
+const Container = styled(FlexDivCentered)`
 	width: 568px;
 	height: 44px;
 	background-color: ${(props) => props.theme.colors.mediumBlue};

--- a/sections/shared/Layout/Banner/index.ts
+++ b/sections/shared/Layout/Banner/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Banner';
+export { default, BannerType } from './Banner';

--- a/sections/shared/Layout/Header.tsx
+++ b/sections/shared/Layout/Header.tsx
@@ -1,25 +1,14 @@
 import { FC } from 'react';
 import styled from 'styled-components';
-import { FlexDivCentered, ExternalLink } from 'styles/common';
-import { Trans } from 'react-i18next';
+import { FlexDivCentered } from 'styles/common';
 
 import UserMenu from './UserMenu';
-import Banner from 'sections/shared/Layout/Banner';
-
-import { LOCAL_STORAGE_KEYS } from 'constants/storage';
+import BannerManager from 'components/BannerManager';
 
 const Header: FC = () => {
 	return (
 		<HeaderWrapper>
-			<Banner
-				localStorageKey={LOCAL_STORAGE_KEYS.WARNING_URL_BANNER_VISIBLE}
-				message={
-					<Trans
-						i18nKey={'user-menu.banner.warning-url'}
-						components={[<StyledExternalLink href="https://staking.synthetix.io" />]}
-					/>
-				}
-			/>
+			<BannerManager />
 			<Container>
 				<UserMenu />
 			</Container>
@@ -34,14 +23,6 @@ const HeaderWrapper = styled.div`
 const Container = styled(FlexDivCentered)`
 	justify-content: flex-end;
 	padding: 24px 30px 0 0;
-`;
-
-const StyledExternalLink = styled(ExternalLink)`
-	color: ${(props) => props.theme.colors.white};
-	text-decoration: underline;
-	&:hover {
-		text-decoration: underline;
-	}
 `;
 
 export default Header;

--- a/translations/en.json
+++ b/translations/en.json
@@ -1090,7 +1090,8 @@
 			"connected-to-l2": "Layer 2"
 		},
 		"banner": {
-			"warning-url": "WARNING: Please make sure the URL is <0>staking.synthetix.io</0> (bookmark this page to be safe)"
+			"url-warning": "ATTENTION: Please make sure the URL is <0>staking.synthetix.io</0> (bookmark this page to be safe)",
+			"liquidation-warning": "WARNING: Your staked SNX may be liquidated if you don't bring your C-Ratio above <0>{{liquidationRatio}}%</0> before <1>{{liquidationDeadline}}</1>. Click <2>here</2> for more info."
 		},
 		"error": {
 			"please-install-metamask": "Please install Metamask or manually add the Optimism network to your browser wallet."


### PR DESCRIPTION
<img width="843" alt="Screen Shot 2021-05-25 at 4 48 56 pm" src="https://user-images.githubusercontent.com/690350/119451911-1ec74380-bd79-11eb-94c9-00950f4bf72e.png">

This PR will display the liquidation banner as a priority. I don't think we've got a design good enough to have multiple banners at the moment. Hence the `if` statement in `BannerManager.tsx`.

This code could definitely be better at some point, to handle multiple banners at the same time.