### PR TITLE
fix: EthWrapper sETH is not part of the debt pool

### DIFF
--- a/components/StatsSection/StatsSection.tsx
+++ b/components/StatsSection/StatsSection.tsx
@@ -39,6 +39,7 @@ const StatsSection: FC = ({ children }) => {
 	const snxPriceChartData = useMemo(() => {
 		return (SNX24hrPricesQuery?.data ?? [])
 			.map((dataPoint) => ({ value: dataPoint.averagePrice }))
+			.slice()
 			.reverse();
 	}, [SNX24hrPricesQuery?.data]);
 

--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -67,14 +67,17 @@ const useHistoricalDebtData = () => {
 
 			// We merge both actual & issuance debt into an array
 			let historicalDebtAndIssuance: HistoricalDebtAndIssuanceData[] = [];
-			debtHistory.reverse().forEach((debtSnapshot, i) => {
-				historicalDebtAndIssuance.push({
-					timestamp: debtSnapshot.timestamp,
-					issuanceDebt: historicalIssuanceAggregation[i],
-					actualDebt: debtSnapshot.debtBalanceOf,
-					index: i,
+			debtHistory
+				.slice()
+				.reverse()
+				.forEach((debtSnapshot, i) => {
+					historicalDebtAndIssuance.push({
+						timestamp: debtSnapshot.timestamp,
+						issuanceDebt: historicalIssuanceAggregation[i],
+						actualDebt: debtSnapshot.debtBalanceOf,
+						index: i,
+					});
 				});
-			});
 
 			// Last occurrence is the current state of the debt
 			// Issuance debt = last occurrence of the historicalDebtAndIssuance array

--- a/queries/rates/useHistoricalRatesQuery.ts
+++ b/queries/rates/useHistoricalRatesQuery.ts
@@ -42,7 +42,7 @@ const useHistoricalRatesQuery = (
 				const change = calculateRateChange(rates);
 
 				return {
-					rates: rates.reverse(),
+					rates: rates.slice().reverse(),
 					low,
 					high,
 					change,

--- a/sections/debt/components/DebtPieChart/DebtPieChart.tsx
+++ b/sections/debt/components/DebtPieChart/DebtPieChart.tsx
@@ -1,8 +1,10 @@
 import { FC, useMemo } from 'react';
 import styled from 'styled-components';
 
-import { SynthTotalSupply, SynthsTotalSupplyData } from 'queries/synths/useSynthsTotalSupplyQuery';
-import useSynthsTotalSupplyQuery from 'queries/synths/useSynthsTotalSupplyQuery';
+import useSynthsTotalSupplyQuery, {
+	SynthTotalSupply,
+	SynthsTotalSupplyData,
+} from 'queries/synths/useSynthsTotalSupplyQuery';
 
 import PieChart from 'components/PieChart';
 import DebtPoolTable from '../DebtPoolTable';

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Wrapper.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Wrapper.tsx
@@ -316,6 +316,7 @@ function toHumanizedDuration(ms: Big) {
 		ms = ms.minus(z).dividedBy(u.mod);
 	});
 	return units
+		.slice()
 		.reverse()
 		.filter((u) => {
 			return u.label !== 'ms'; // && dur[u.label]

--- a/sections/shared/Layout/SideNav/DesktopSideNav.tsx
+++ b/sections/shared/Layout/SideNav/DesktopSideNav.tsx
@@ -45,6 +45,7 @@ const DesktopSideNav: FC = () => {
 	const snxPriceChartData = useMemo(() => {
 		return (SNX24hrPricesQuery?.data ?? [])
 			.map((dataPoint) => ({ value: dataPoint.averagePrice }))
+			.slice()
 			.reverse();
 	}, [SNX24hrPricesQuery?.data]);
 


### PR DESCRIPTION
Fixes the shown sETH value to not include sETH issued by [EthWrapper](https://sips.synthetix.io/sips/sip-112) because the later is not part of the debt pool.

QA Task:
- Go to https://staking-git-fix-global-debt-pool-stat-synthetixio.vercel.app/debt
- Ensure the global debt pool pie chart matches the one at https://stats.synthetix.io/