### PR TITLE
fix: tokenlists regression

### DIFF
--- a/components/Currency/CurrencyIcon/CurrencyIcon.tsx
+++ b/components/Currency/CurrencyIcon/CurrencyIcon.tsx
@@ -33,9 +33,9 @@ export const getSynthIcon = (currencyKey: CurrencyKey) =>
 	`https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/synths/${currencyKey}.svg`;
 
 export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest }) => {
-	const [error, setError] = useState<boolean>(false);
 	const [firstFallbackError, setFirstFallbackError] = useState<boolean>(false);
 	const [secondFallbackError, setSecondFallbackError] = useState<boolean>(false);
+	const [thirdFallbackError, setThirdFallbackError] = useState<boolean>(false);
 
 	const synthetixTokenListQuery = useSynthetixTokenList();
 	const synthetixTokenListMap = synthetixTokenListQuery.isSuccess
@@ -53,46 +53,37 @@ export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest
 		: null;
 
 	const props = {
-		width: '36px',
-		height: '36px',
+		width: '24px',
+		height: '24px',
 		alt: currencyKey,
 		...rest,
 	};
 
-	const defaultIcon = (
-		<Placeholder style={{ width: props.width, height: props.height }}>{currencyKey}</Placeholder>
-	);
-
-	if (type === 'token') {
-		if (
-			ZapperTokenListMap != null &&
-			ZapperTokenListMap[currencyKey] != null &&
-			!firstFallbackError
-		) {
-			return (
-				<TokenIcon
-					src={ZapperTokenListMap[currencyKey].logoURI}
-					onError={() => setFirstFallbackError(true)}
-					{...props}
-				/>
-			);
-		} else if (
-			OneInchTokenListMap != null &&
-			OneInchTokenListMap[currencyKey] != null &&
-			!secondFallbackError
-		) {
-			return (
-				<TokenIcon
-					src={OneInchTokenListMap[currencyKey].logoURI}
-					onError={() => setSecondFallbackError(true)}
-					{...props}
-				/>
-			);
-		} else {
-			return defaultIcon;
-		}
-	} else {
-		if (error) return defaultIcon;
+	if (
+		ZapperTokenListMap != null &&
+		ZapperTokenListMap[currencyKey] != null &&
+		!firstFallbackError
+	) {
+		return (
+			<TokenIcon
+				src={ZapperTokenListMap[currencyKey].logoURI}
+				onError={() => setFirstFallbackError(true)}
+				{...props}
+			/>
+		);
+	} else if (
+		OneInchTokenListMap != null &&
+		OneInchTokenListMap[currencyKey] != null &&
+		!secondFallbackError
+	) {
+		return (
+			<TokenIcon
+				src={OneInchTokenListMap[currencyKey].logoURI}
+				onError={() => setSecondFallbackError(true)}
+				{...props}
+			/>
+		);
+	} else if (thirdFallbackError) {
 		switch (currencyKey) {
 			case CryptoCurrency.ETH: {
 				return <Img src={ETHIcon} {...props} />;
@@ -108,12 +99,16 @@ export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest
 								? synthetixTokenListMap[currencyKey].logoURI
 								: getSynthIcon(currencyKey)
 						}
-						onError={() => setError(true)}
+						onError={() => setThirdFallbackError(true)}
 						{...props}
 						alt={currencyKey}
 					/>
 				);
 		}
+	} else {
+		return (
+			<Placeholder style={{ width: props.width, height: props.height }}>{currencyKey}</Placeholder>
+		);
 	}
 };
 


### PR DESCRIPTION
Bug causing zapper and 1inch options to not be attempted.

<img width="696" alt="Screenshot 2021-06-04 at 21 53 59" src="https://user-images.githubusercontent.com/60554509/120849888-60c56600-c57f-11eb-9b6f-4fffe5a57b31.png">

<img width="671" alt="Screenshot 2021-06-04 at 21 54 11" src="https://user-images.githubusercontent.com/60554509/120849907-66bb4700-c57f-11eb-82f9-a79d5bea8c9a.png">
