### PR TITLE
check if cratio is below target

### DIFF
--- a/hooks/useUserStakingData.ts
+++ b/hooks/useUserStakingData.ts
@@ -23,7 +23,13 @@ export const useUserStakingData = () => {
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const totalIssuedSynthsExclEth = useTotalIssuedSynthsExcludingEtherQuery(Synths.sUSD);
 	const previousFeePeriod = useGetFeePoolDataQuery('1');
-	const { currentCRatio, targetCRatio, debtBalance, collateral } = useStakingCalculations();
+	const {
+		currentCRatio,
+		targetCRatio,
+		debtBalance,
+		collateral,
+		targetThreshold,
+	} = useStakingCalculations();
 	const useSNXLockedValue = useSNXLockedValueQuery();
 	const debtData = useGetDebtDataQuery();
 	const feesToDistribute = previousFeePeriod?.data?.feesToDistribute ?? 0;
@@ -34,6 +40,9 @@ export const useUserStakingData = () => {
 	const sUSDRate = toBigNumber(exchangeRatesQuery.data?.sUSD ?? 0);
 	const SNXRate = toBigNumber(exchangeRatesQuery.data?.SNX ?? 0);
 
+	const isBelowCRatio = currentCRatio.isGreaterThan(
+		targetCRatio.multipliedBy(toBigNumber(1).plus(targetThreshold))
+	);
 	const stakedValue =
 		collateral.gt(0) && currentCRatio.gt(0)
 			? collateral
@@ -113,6 +122,7 @@ export const useUserStakingData = () => {
 		tradingRewards,
 		stakingRewards,
 		debtBalance,
+		isBelowCRatio,
 	};
 };
 

--- a/queries/debt/useGetDebtDataQuery.ts
+++ b/queries/debt/useGetDebtDataQuery.ts
@@ -19,6 +19,7 @@ type WalletDebtData = {
 	issuableSynths: BigNumber;
 	balance: BigNumber;
 	totalSupply: BigNumber;
+	targetThreshold: BigNumber;
 };
 
 const useGetDebtDataQuery = (options?: QueryConfig<WalletDebtData>) => {
@@ -44,6 +45,7 @@ const useGetDebtDataQuery = (options?: QueryConfig<WalletDebtData>) => {
 				Synthetix.maxIssuableSynths(walletAddress),
 				Synthetix.balanceOf(walletAddress),
 				Synthetix.totalSupply(),
+				SystemSettings.targetThreshold(),
 			]);
 			const [
 				targetCRatio,
@@ -54,6 +56,7 @@ const useGetDebtDataQuery = (options?: QueryConfig<WalletDebtData>) => {
 				issuableSynths,
 				balance,
 				totalSupply,
+				targetThreshold,
 			] = result.map((item) => toBigNumber(utils.formatEther(item)));
 			return {
 				targetCRatio,
@@ -64,6 +67,7 @@ const useGetDebtDataQuery = (options?: QueryConfig<WalletDebtData>) => {
 				issuableSynths,
 				balance,
 				totalSupply,
+				targetThreshold,
 			};
 		},
 		{

--- a/sections/staking/hooks/useStakingCalculations.ts
+++ b/sections/staking/hooks/useStakingCalculations.ts
@@ -21,6 +21,7 @@ const useStakingCalculations = () => {
 		const SNXRate = toBigNumber(exchangeRates?.SNX ?? 0);
 		const collateral = toBigNumber(debtData?.collateral ?? 0);
 		const targetCRatio = toBigNumber(debtData?.targetCRatio ?? 0);
+		const targetThreshold = toBigNumber(debtData?.targetThreshold ?? 0);
 		const currentCRatio = toBigNumber(debtData?.currentCRatio ?? 0);
 		const transferableCollateral = toBigNumber(debtData?.transferable ?? 0);
 		const debtBalance = toBigNumber(debtData?.debtBalance ?? 0);
@@ -55,6 +56,7 @@ const useStakingCalculations = () => {
 		return {
 			collateral,
 			targetCRatio,
+			targetThreshold,
 			percentageTargetCRatio,
 			currentCRatio,
 			percentageCurrentCRatio,


### PR DESCRIPTION
- Added a check in order to know if current c-ratio is below target c-ratio (`targetThreshold` also taken into account)
- Small refactoring in the claim screen as the `burn sUSD` button was disabled (and it shouldn't)