### PR TITLE
[Feature]: Add a selectable buffer when trying to burn max debt on Staking dApp

### DIFF
--- a/components/BufferSelector/BufferSelector.tsx
+++ b/components/BufferSelector/BufferSelector.tsx
@@ -1,0 +1,183 @@
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import Tippy from '@tippyjs/react';
+import { useTranslation } from 'react-i18next';
+import { Svg } from 'react-optimized-image';
+
+import InfoIcon from 'assets/svg/app/info.svg';
+
+import Button from 'components/Button';
+
+import { NumericValue, FlexDivRowCentered, FlexDivRow } from 'styles/common';
+
+import { formatPercent } from 'utils/formatters/number';
+import NumericInput from 'components/Input/NumericInput';
+
+type BufferSelectorProps = {
+	setBuffer: (num: string) => void;
+	buffer: string;
+};
+
+const BufferSelector: React.FC<BufferSelectorProps> = ({ buffer, setBuffer, ...rest }) => {
+	const { t } = useTranslation();
+
+	const [customBuffer, setCustomBuffer] = useState<string>('');
+
+	const BUFFER_VALUES = useMemo(
+		() => [
+			{
+				text: t('common.buffer.low'),
+				value: '0.0010',
+			},
+			{
+				text: t('common.buffer.medium'),
+				value: '0.0025',
+			},
+			{
+				text: t('common.buffer.high'),
+				value: '0.0050',
+			},
+		],
+		[t]
+	);
+
+	const hasCustomBuffer = customBuffer !== '';
+
+	const bufferItem = hasCustomBuffer ? (
+		<span data-testid="gas-price">{formatPercent(customBuffer)}</span>
+	) : (
+		<span data-testid="gas-price">{formatPercent(buffer)}</span>
+	);
+
+	const content = (
+		<BufferSelectContainer>
+			<div>
+				<CustomSlippage
+					value={customBuffer}
+					onChange={(_, value) => setCustomBuffer(value)}
+					placeholder={t('common.custom')}
+				/>
+			</div>
+			{BUFFER_VALUES.map(({ text, value }) => (
+				<StyledBufferButton
+					key={text}
+					variant="solid"
+					onClick={() => {
+						setCustomBuffer('');
+						setBuffer(value);
+					}}
+					isActive={hasCustomBuffer ? false : buffer === value}
+				>
+					<BufferText>{text}</BufferText>
+					<NumericValue>{formatPercent(value)}</NumericValue>
+				</StyledBufferButton>
+			))}
+		</BufferSelectContainer>
+	);
+
+	return (
+		<Container {...rest}>
+			<FlexDivRowCentered>
+				<BufferHeader>{t('common.buffer.title')}</BufferHeader>
+				<BufferHelperTooltip content={<span>{t('common.buffer.helper')}</span>} arrow={false}>
+					<InfoIconWrapper>
+						<Svg src={InfoIcon} />
+					</InfoIconWrapper>
+				</BufferHelperTooltip>
+			</FlexDivRowCentered>
+			<FlexDivRowCentered>
+				<BufferItem>
+					<BufferText>{bufferItem}</BufferText>
+				</BufferItem>
+				<BufferTooltip trigger="click" arrow={false} content={content} interactive={true}>
+					<StyledBufferEditButton role="button">{t('common.edit')}</StyledBufferEditButton>
+				</BufferTooltip>
+			</FlexDivRowCentered>
+		</Container>
+	);
+};
+export default BufferSelector;
+
+const Container = styled(FlexDivRow)`
+	width: 100%;
+	justify-content: space-between;
+`;
+
+const BufferHeader = styled.p`
+	font-family: ${(props) => props.theme.fonts.interBold};
+	font-size: 12px;
+	color: ${(props) => props.theme.colors.gray};
+	text-transform: uppercase;
+`;
+
+const BufferSelectContainer = styled.div`
+	padding: 16px 0 8px 0;
+`;
+
+const BufferHelperTooltip = styled(Tippy)`
+	background: ${(props) => props.theme.colors.navy};
+	border: 0.5px solid ${(props) => props.theme.colors.navy};
+	border-radius: 4px;
+	width: 120px;
+	.tippy-content {
+		padding: 0;
+	}
+`;
+
+const BufferTooltip = styled(Tippy)`
+	background: ${(props) => props.theme.colors.navy};
+	border: 0.5px solid ${(props) => props.theme.colors.navy};
+	border-radius: 4px;
+	width: 120px;
+`;
+
+const CustomSlippage = styled(NumericInput)`
+	width: 100%;
+	border: 0;
+	font-size: 12px;
+	::placeholder {
+		font-family: ${(props) => props.theme.fonts.mono};
+	}
+`;
+
+const BufferText = styled.span`
+	font-family: ${(props) => props.theme.fonts.interBold};
+	font-size: 12px;
+	color: ${(props) => props.theme.colors.white};
+`;
+
+const BufferItem = styled.span`
+	display: inline-flex;
+	align-items: center;
+	svg {
+		margin-left: 5px;
+	}
+`;
+
+const StyledBufferButton = styled(Button)`
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding-left: 10px;
+	padding-right: 10px;
+	font-size: 12px;
+`;
+
+const InfoIconWrapper = styled.span`
+	display: inline-flex;
+	align-items: center;
+	cursor: pointer;
+	svg {
+		margin-left: 5px;
+	}
+`;
+
+const StyledBufferEditButton = styled.span`
+	font-family: ${(props) => props.theme.fonts.interBold};
+	padding-left: 5px;
+	font-size: 12px;
+	cursor: pointer;
+	color: ${(props) => props.theme.colors.blue};
+	text-transform: uppercase;
+`;

--- a/components/BufferSelector/BufferSelector.tsx
+++ b/components/BufferSelector/BufferSelector.tsx
@@ -54,7 +54,10 @@ const BufferSelector: React.FC<BufferSelectorProps> = ({ buffer, setBuffer, ...r
 			<div>
 				<CustomSlippage
 					value={customBuffer}
-					onChange={(_, value) => setCustomBuffer(value)}
+					onChange={(_, value) => {
+						setBuffer(value);
+						setCustomBuffer(value);
+					}}
 					placeholder={t('common.custom')}
 				/>
 			</div>

--- a/components/BufferSelector/BufferSelector.tsx
+++ b/components/BufferSelector/BufferSelector.tsx
@@ -123,7 +123,7 @@ const BufferHelperTooltip = styled(Tippy)`
 	border-radius: 4px;
 	width: 120px;
 	.tippy-content {
-		padding: 0;
+		padding: 10px;
 	}
 `;
 

--- a/components/BufferSelector/index.ts
+++ b/components/BufferSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BufferSelector';

--- a/components/GasSelector/GasSelector.tsx
+++ b/components/GasSelector/GasSelector.tsx
@@ -91,14 +91,14 @@ const GasSelector: React.FC<GasSelectorProps> = ({
 
 	const content = (
 		<GasSelectContainer>
-			<CustomGasPriceContainer>
+			<div>
 				<CustomGasPrice
 					value={customGasPrice}
 					onChange={(_, value) => setCustomGasPrice(value)}
 					placeholder={t('common.custom')}
 					data-testid="edit-gas-price-input"
 				/>
-			</CustomGasPriceContainer>
+			</div>
 			{GAS_SPEEDS.map((speed) => (
 				<StyedGasButton
 					key={speed}
@@ -208,8 +208,6 @@ const GasPriceTooltip = styled(Tippy)`
 const GasSelectContainer = styled.div`
 	padding: 16px 0 8px 0;
 `;
-
-const CustomGasPriceContainer = styled.div``;
 
 const CustomGasPrice = styled(NumericInput)`
 	width: 100%;

--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -20,6 +20,7 @@ export const DEFAULT_NETWORK_ID = NetworkId.Mainnet;
 
 export const DEFAULT_GAS_LIMIT = 500000;
 export const DEFAULT_GAS_BUFFER = 15000;
+export const DEFAULT_DEBT_BUFFER = '0.0025';
 
 // ui defaults
 export const DEFAULT_SEARCH_DEBOUNCE_MS = 300;

--- a/sections/staking/components/StakingInfo/BurnInfo.tsx
+++ b/sections/staking/components/StakingInfo/BurnInfo.tsx
@@ -110,7 +110,6 @@ const StakingInfo: FC = () => {
 					title: t('staking.info.table.susd-balance'),
 					value: sanitiseValue(sUSDBalance),
 					changedValue: sanitiseValue(changedSUSDBalance),
-					currencyKey: Synths.sUSD,
 				},
 				{
 					title: t('staking.info.table.debt'),

--- a/sections/staking/components/StakingInfo/InfoLayout.tsx
+++ b/sections/staking/components/StakingInfo/InfoLayout.tsx
@@ -40,7 +40,7 @@ type RowData = {
 	title: string;
 	value: BigNumber;
 	changedValue: BigNumber;
-	currencyKey: CryptoCurrency | string;
+	currencyKey?: CryptoCurrency | string;
 };
 
 type StakingInfo = {

--- a/sections/staking/components/StakingInfo/InfoLayout.tsx
+++ b/sections/staking/components/StakingInfo/InfoLayout.tsx
@@ -24,7 +24,8 @@ import {
 	InfoContainer,
 	InfoHeader,
 } from '../common';
-import { StakingPanelType } from 'store/staking';
+import { BurnActionType, burnTypeState, StakingPanelType } from 'store/staking';
+import { useRecoilValue } from 'recoil';
 
 type BarChartData = {
 	title: string;
@@ -56,6 +57,7 @@ type InfoLayoutProps = {
 
 const InfoLayout: FC<InfoLayoutProps> = ({ stakingInfo, collateral, isInputEmpty, infoType }) => {
 	const { t } = useTranslation();
+	const burnType = useRecoilValue(burnTypeState);
 
 	const title = useMemo(() => {
 		switch (infoType) {
@@ -126,6 +128,10 @@ const InfoLayout: FC<InfoLayoutProps> = ({ stakingInfo, collateral, isInputEmpty
 							{!isInputEmpty && (
 								<>
 									<StyledArrowRight src={ArrowRightIcon} />
+									{title === t('staking.info.table.susd-balance') &&
+										infoType === StakingPanelType.BURN &&
+										burnType === BurnActionType.MAX &&
+										`~`}
 									<RowValue>
 										{formatCurrency(currencyKey, !changedValue.isNaN() ? changedValue : 0, {
 											currencyKey: currencyKey,

--- a/sections/staking/components/StakingInfo/MintInfo.tsx
+++ b/sections/staking/components/StakingInfo/MintInfo.tsx
@@ -101,7 +101,6 @@ const StakingInfo: FC = () => {
 					title: t('staking.info.table.susd-balance'),
 					value: sanitiseValue(sUSDBalance),
 					changedValue: sanitiseValue(changedSUSDBalance),
-					currencyKey: Synths.sUSD,
 				},
 				{
 					title: t('staking.info.table.debt'),

--- a/sections/staking/components/StakingInput/StakingInput.tsx
+++ b/sections/staking/components/StakingInput/StakingInput.tsx
@@ -48,6 +48,7 @@ import Connector from 'containers/Connector';
 import { BurnActionType, burnTypeState } from 'store/staking';
 import Button from 'components/Button';
 import Currency from 'components/Currency';
+import BufferSelector from 'components/BufferSelector';
 
 type StakingInputProps = {
 	onSubmit: () => void;
@@ -69,6 +70,8 @@ type StakingInputProps = {
 	etherNeededToBuy?: string;
 	sUSDNeededToBuy?: string;
 	sUSDNeededToBurn?: string;
+	setDebtBuffer?: (num: string) => void;
+	debtBuffer?: string;
 };
 
 const StakingInput: React.FC<StakingInputProps> = ({
@@ -91,6 +94,8 @@ const StakingInput: React.FC<StakingInputProps> = ({
 	etherNeededToBuy,
 	sUSDNeededToBuy,
 	sUSDNeededToBurn,
+	setDebtBuffer,
+	debtBuffer,
 }) => {
 	const {
 		targetCRatio,
@@ -107,6 +112,7 @@ const StakingInput: React.FC<StakingInputProps> = ({
 
 	const [stakingCurrencyKey] = useState<string>(CryptoCurrency.SNX);
 	const [synthCurrencyKey] = useState<string>(Synths.sUSD);
+
 	/**
 	 * Given the amount to mint, returns the equivalent collateral needed for stake.
 	 * @param mintInput Amount to mint
@@ -327,6 +333,11 @@ const StakingInput: React.FC<StakingInputProps> = ({
 						</RowTitle>
 						<RowValue>{equivalentSNXAmount}</RowValue>
 					</DataRow>
+					{burnType === BurnActionType.MAX && debtBuffer && setDebtBuffer && (
+						<DataRow>
+							<BufferSelector buffer={debtBuffer} setBuffer={setDebtBuffer} />
+						</DataRow>
+					)}
 					<DataRow>
 						<GasSelector gasLimitEstimate={gasLimitEstimate} setGasPrice={setGasPrice} />
 					</DataRow>

--- a/translations/en.json
+++ b/translations/en.json
@@ -1193,6 +1193,12 @@
 			"buy-currency": "Buy <0>{{currencyKey}}</0>",
 			"synthetic-currency-name": "Synthetic {{currencyName}}"
 		},
+		"buffer": {
+			"title": "Debt Buffer",
+			"low": "Low",
+			"medium": "Avg",
+			"high": "High"
+		},
 		"gas-prices": {
 			"est": "Est Fees: {{amount}}",
 			"average": "Average",
@@ -1202,6 +1208,7 @@
 		"custom": "Custom",
 		"edit": "Edit",
 		"convert": "Convert",
+		"debt-buffer-header": "Debt Buffer Percent",
 		"gas-header": "Gas Price (GWEI)",
 		"explorers": {
 			"etherscan": "etherscan"

--- a/translations/en.json
+++ b/translations/en.json
@@ -1195,6 +1195,7 @@
 		},
 		"buffer": {
 			"title": "Debt Buffer",
+			"helper": "Add a buffer to combat the debt moving while the tx is processing",
 			"low": "Low",
 			"medium": "Avg",
 			"high": "High"


### PR DESCRIPTION
Fixes https://github.com/synthetixio/issues/issues/190

To test
1) Mint max
2) Try to burnMax (input should be blocked if you choose a slippage > 0, unless you have spare sUSD)
3) Acquire more sUSD
4) Try to burn with buffer, if successful it should burn only the debt YOU have and not more

Other notes
- Should allow for 0% buffer burning max

![image](https://user-images.githubusercontent.com/39738607/124705797-8b695c80-df39-11eb-8cf9-53525c97ca51.png)

![image](https://user-images.githubusercontent.com/39738607/124705824-9ae8a580-df39-11eb-9ab5-ca074cdf1944.png)
