### PR TITLE
Fix the claim errors on L2 not showing

### DIFF
--- a/sections/earn/ClaimTab/ClaimTab.tsx
+++ b/sections/earn/ClaimTab/ClaimTab.tsx
@@ -155,10 +155,23 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 
 					setGasLimitEstimate(gasEstimate);
 				} catch (error) {
-					if (error.message.includes('below penalty threshold')) {
-						setLowCRatio(true);
-					} else if (!error.message.includes('already claimed')) {
-						setError(error.message);
+					/* L2 errors are different to L1
+						data: {
+							message: "error message"
+						}
+					*/
+					if (isL2) {
+						if (error.data.message.includes('below penalty threshold')) {
+							setLowCRatio(true);
+						} else if (!error.data.message.includes('already claimed')) {
+							setError(error.data.message);
+						}
+					} else {
+						if (error.message.includes('below penalty threshold')) {
+							setLowCRatio(true);
+						} else if (!error.message.includes('already claimed')) {
+							setError(error.message);
+						}
 					}
 					setGasLimitEstimate(null);
 				}

--- a/sections/earn/ClaimTab/ClaimTab.tsx
+++ b/sections/earn/ClaimTab/ClaimTab.tsx
@@ -155,12 +155,7 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 
 					setGasLimitEstimate(gasEstimate);
 				} catch (error) {
-					/* L2 errors are different to L1
-						data: {
-							message: "error message"
-						}
-					*/
-					if (isL2) {
+					if (isL2 && error.data) {
 						if (error.data.message.includes('below penalty threshold')) {
 							setLowCRatio(true);
 						} else if (!error.data.message.includes('already claimed')) {
@@ -215,7 +210,7 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 				} catch (e) {
 					setTransactionState(Transaction.PRESUBMIT);
 					if (isL2) {
-						setError(e.data.message);
+						setError(e?.data?.message ?? e.message);
 					} else {
 						setError(e.message);
 					}

--- a/sections/earn/ClaimTab/ClaimTab.tsx
+++ b/sections/earn/ClaimTab/ClaimTab.tsx
@@ -214,7 +214,11 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 					}
 				} catch (e) {
 					setTransactionState(Transaction.PRESUBMIT);
-					setError(e.message);
+					if (isL2) {
+						setError(e.data.message);
+					} else {
+						setError(e.message);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Notes: On L2 the claim errors were all showing an ambiguous error "Internal JSON RPC error" this is because the error object is different to the one on L1 

