### PR TITLE
Update useClaimStatus to take an optional transactionState arg.

### DIFF
--- a/sections/earn/ClaimTab/ClaimTab.tsx
+++ b/sections/earn/ClaimTab/ClaimTab.tsx
@@ -94,7 +94,6 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 	const delegateWallet = useRecoilValue(delegateWalletState);
 	const { useHasVotedForElectionsQuery } = useSynthetixQueries();
 
-	const claimed = useClaimedStatus();
 	const { isBelowCRatio } = useUserStakingData(delegateWallet?.address ?? walletAddress);
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const { blockExplorerInstance } = Etherscan.useContainer();
@@ -114,6 +113,7 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 	const [transactionState, setTransactionState] = useState<Transaction>(Transaction.PRESUBMIT);
 	const [txHash, setTxHash] = useState<string | null>(null);
 	const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
+	const claimed = useClaimedStatus(transactionState);
 
 	const hasVotedForElections = useHasVotedForElectionsQuery(snapshotEndpoint, walletAddress);
 

--- a/sections/hooks/useClaimedStatus.test.tsx
+++ b/sections/hooks/useClaimedStatus.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useSynthetixQueries, { StakingTransactionType } from '@synthetixio/queries';
 import useClaimedStatus from './useClaimedStatus';
 import { RecoilRoot } from 'recoil';
+import { Transaction } from 'constants/network';
 
 jest.mock('@synthetixio/queries');
 const useSynthetixQueriesMock = useSynthetixQueries as jest.MockedFunction<
@@ -77,5 +78,46 @@ describe('useClaimedStatus', () => {
 		const { result } = renderHook(() => useClaimedStatus(), { wrapper });
 
 		expect(result.current).toBe(false);
+	});
+	test('refetch when passed transaction state changes to SUCCESS', () => {
+		const feeStartTimeMs = new Date('2021-10-10T20:00:00.000Z').getTime();
+		const refetchMock = jest.fn();
+		const useFeeClaimHistoryQueryMock = jest.fn().mockReturnValue({
+			data: [
+				{ type: StakingTransactionType.Issued, timestamp: new Date().getTime() }, // should be ignored, we only care about fees claimed
+			],
+			refetch: refetchMock,
+		});
+		useSynthetixQueriesMock.mockReturnValue({
+			useFeeClaimHistoryQuery: useFeeClaimHistoryQueryMock,
+			useGetFeePoolDataQuery: jest.fn().mockReturnValue({
+				data: {
+					startTime: feeStartTimeMs / 1000,
+					feePeriodDuration: 60 * 60, // 1hour in seconds,
+				},
+			}),
+		} as any);
+
+		const { result } = renderHook(() => useClaimedStatus(Transaction.PRESUBMIT), { wrapper });
+		expect(result.current).toBe(false);
+		expect(refetchMock).not.toBeCalled();
+
+		// Update the mock to include FeesClaimed transaction
+		useFeeClaimHistoryQueryMock.mockClear().mockReturnValue({
+			data: [
+				{
+					type: StakingTransactionType.FeesClaimed,
+					timestamp: feeStartTimeMs + 60 * 1000, // has claimed after period start (and before next period)
+				},
+				{ type: StakingTransactionType.Issued, timestamp: new Date().getTime() }, // should be ignored, we only care about fees claimed
+			],
+			refetch: refetchMock,
+		});
+
+		const { result: result1 } = renderHook(() => useClaimedStatus(Transaction.SUCCESS), {
+			wrapper,
+		});
+		expect(refetchMock).toBeCalled();
+		expect(result1.current).toBe(true);
 	});
 });

--- a/sections/hooks/useClaimedStatus.ts
+++ b/sections/hooks/useClaimedStatus.ts
@@ -1,16 +1,22 @@
 import useSynthetixQueries from '@synthetixio/queries';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { walletAddressState } from 'store/wallet';
 import { isAfter, isBefore } from 'date-fns';
+import { Transaction } from 'constants/network';
 
-export const useClaimedStatus = () => {
+export const useClaimedStatus = (transactionState?: Transaction) => {
 	const walletAddress = useRecoilValue(walletAddressState);
 	const { useFeeClaimHistoryQuery, useGetFeePoolDataQuery } = useSynthetixQueries();
 
-	const history = useFeeClaimHistoryQuery(walletAddress);
+	const { data: historyData, refetch } = useFeeClaimHistoryQuery(walletAddress);
 	const currentFeePeriod = useGetFeePoolDataQuery(0);
-
+	useEffect(() => {
+		// If a transactionState was passed and it just changed to Success, refetch
+		if (transactionState === Transaction.SUCCESS) {
+			refetch();
+		}
+	}, [refetch, transactionState]);
 	const { currentFeePeriodStarts, nextFeePeriodStarts } = useMemo(() => {
 		return {
 			currentFeePeriodStarts: new Date(
@@ -24,8 +30,8 @@ export const useClaimedStatus = () => {
 		};
 	}, [currentFeePeriod]);
 
-	return history.data
-		? history.data?.some((tx) => {
+	return historyData
+		? historyData?.some((tx) => {
 				const claimedDate = new Date(tx.timestamp);
 				return (
 					tx.type === 'feesClaimed' &&


### PR DESCRIPTION
When I clicked claim I had to refresh to get the claim button to update.
I try to resolve that in this PR. My solution lets you pass an optional `transactionState` argument to the `useClaimedStatus` hook. If this `transactionState` changes to `SUCCESS` we refetch the transaction history.

It make sense that it wouldn't refetch before since all we pass to `useFeeClaimHistoryQuery` is the `walletAddress`.
I did write test for it. BUT I already have claimed on my testing account so to actually test it I need some web3 guidance on how to work around that. Or I guess just test it tomorrow...