### PR TITLE
Make sure gas price doesn't have decimals

### DIFF
--- a/sections/earn/ClaimTab/ClaimTab.tsx
+++ b/sections/earn/ClaimTab/ClaimTab.tsx
@@ -227,13 +227,15 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 						gasLimit = normalizeGasLimit(gasLimit);
 					}
 
+					const normalizedGasPriceValue = Math.round(normalizedGasPrice(gasPrice.toNumber()));
+
 					const transaction: ethers.ContractTransaction = delegateWallet
 						? await FeePool.claimOnBehalf(delegateWallet.address, {
-								gasPrice: normalizedGasPrice(gasPrice.toNumber()),
+								gasPrice: normalizedGasPriceValue,
 								gasLimit,
 						  })
 						: await FeePool.claimFees({
-								gasPrice: normalizedGasPrice(gasPrice.toNumber()),
+								gasPrice: normalizedGasPriceValue,
 								gasLimit,
 						  });
 
@@ -252,6 +254,7 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 						setTxModalOpen(false);
 					}
 				} catch (e) {
+					console.log(e);
 					setTransactionState(Transaction.PRESUBMIT);
 					if (isL2) {
 						setError(e?.data?.message ?? e.message);


### PR DESCRIPTION
I'm not sure if this is Kovan related but in some gases the gas price has decimals. This is causing Big number problems.
The error I saw while trying to claim was:
`Error: underflow (fault="underflow", operation="BigNumber.from", value=2000000007.0000002, code=NUMERIC_FAULT`

Just making sure that the normalised gas price doesn't have decimals seems to do the trick.
I vaguely remember @dbeal-eth  running in to this too but at the time we couldn't reproduce it.