### PR TITLE
Fix/mint number should not show zero

### DIFF
--- a/sections/staking/components/MintTab/MintTab.tsx
+++ b/sections/staking/components/MintTab/MintTab.tsx
@@ -70,6 +70,7 @@ const MintTab: React.FC = () => {
 			case MintActionType.CUSTOM:
 				onSubmit = () => txn.mutate();
 				isLocked = false;
+				inputValue = amountToMint;
 				break;
 			default:
 				return <MintTiles />;
@@ -102,6 +103,7 @@ const MintTab: React.FC = () => {
 		targetCRatio,
 		unstakedCollateral,
 		txn,
+		amountToMint,
 	]);
 
 	return <TabContainer>{returnPanel}</TabContainer>;

--- a/sections/staking/components/MintTab/MintTab.tsx
+++ b/sections/staking/components/MintTab/MintTab.tsx
@@ -90,7 +90,10 @@ const MintTab: React.FC = () => {
 				onInputChange={onMintChange}
 				txHash={txn.hash}
 				transactionState={txn.txnStatus}
-				resetTransaction={txn.refresh}
+				resetTransaction={() => {
+					txn.refresh();
+					setTxModalOpen(false);
+				}}
 			/>
 		);
 	}, [


### PR DESCRIPTION
This PR fixes two issues on the Mint tab
1. When minting cutom amount the transaction modal was not showing any amounts. 
Here minting $10
Before:
<img width="428" alt="Screen Shot 2021-11-22 at 3 41 06 pm" src="https://user-images.githubusercontent.com/5688912/142802306-4434a9ae-524c-4dc9-9230-5c9ad928ee96.png">
After:
<img width="415" alt="Screen Shot 2021-11-22 at 3 41 42 pm" src="https://user-images.githubusercontent.com/5688912/142802317-a70136ef-8a62-4c5b-84e9-3cfdbb9f7f08.png">

2. The other issue fixed is a little more edgecasey. 
 - Mint a custom amount 
 - Dismiss when successfull
 - Then click mint max without reloading the page 
->  Without my fix the transaction modal would show up

