### PR TITLE
 `debtBalanceOf` can be null/undefined and when that is passed to wei we crash.

### DIFF
--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -90,7 +90,7 @@ const useHistoricalDebtData = (walletAddress: string | null) => {
 					historicalDebtAndIssuance.push({
 						timestamp: debtSnapshot.timestamp.toNumber() * 1000,
 						issuanceDebt: historicalIssuanceAggregation[i],
-						actualDebt: wei(debtSnapshot.debtBalanceOf),
+						actualDebt: wei(debtSnapshot.debtBalanceOf || 0),
 						index: i,
 					});
 				});


### PR DESCRIPTION
I dont have total context whats going on. I looked at the result of the problematic wallet.
`debtHistory` is an array and all items expect one have looks like `{timestamp: number, debtBalanceOf: Wei}` the problematic item is missing `debtBalanceOf`, I think it's safe to use 0 there? 