### PR TITLE
Make sure confirmation ui disappears when dismiss button is clicked.

### DIFF
--- a/sections/earn/ClaimTab/ClaimTab.tsx
+++ b/sections/earn/ClaimTab/ClaimTab.tsx
@@ -224,7 +224,7 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 		);
 	}
 
-	if (txn.txnStatus === 'confirmed') {
+	if (txn.txnStatus === 'confirmed' && claimedTradingRewards !== null) {
 		return (
 			<TxState
 				description={


### PR DESCRIPTION
When clicking dismiss we set claimedTradingRewards to null and should then not display the confirmation UI.

I thought this was done already but looks like it disappeared somehow 