### PR TITLE
Dont require voting on L2

### DIFF
--- a/sections/earn/ClaimTab/ClaimAndCloseFeeButton.tsx
+++ b/sections/earn/ClaimTab/ClaimAndCloseFeeButton.tsx
@@ -11,7 +11,7 @@ const ClaimAndCloseFeeButton: React.FC<{
 	handleCloseFeePeriod: () => void;
 	canClaim: boolean;
 	isBelowCRatio: boolean;
-	hasNotVoted: boolean;
+	hasVoted: boolean;
 	hasClaimed: boolean;
 	totalRewards: Wei;
 	isCloseFeePeriodEnabled: boolean;
@@ -23,7 +23,7 @@ const ClaimAndCloseFeeButton: React.FC<{
 	hasClaimed,
 	isCloseFeePeriodEnabled,
 	totalRewards,
-	hasNotVoted,
+	hasVoted,
 }) => {
 	const { t } = useTranslation();
 	const router = useRouter();
@@ -37,7 +37,7 @@ const ClaimAndCloseFeeButton: React.FC<{
 				content={t('earn.actions.claim.ratio-notice')}
 				disabled={!canClaim || !isBelowCRatio}
 			>
-				{hasNotVoted ? (
+				{!hasVoted ? (
 					<PaddedButton variant="primary" onClick={() => router.push(ROUTES.Gov.Home)}>
 						{t('earn.actions.claim.not-voted')}
 					</PaddedButton>

--- a/sections/earn/ClaimTab/ClaimTab.tsx
+++ b/sections/earn/ClaimTab/ClaimTab.tsx
@@ -343,7 +343,11 @@ const ClaimTab: React.FC<ClaimTabProps> = ({ tradingRewards, stakingRewards, tot
 					{error && <ErrorMessage>{error}</ErrorMessage>}
 					{txn.isError && <ErrorMessage>{txn.errorMessage}</ErrorMessage>}
 					<ClaimOrCloseFeeButton
-						hasNotVoted={Boolean(hasVotedForElections.data && !hasVotedForElections.data.hasVoted)}
+						hasVoted={
+							isL2
+								? true // If it's L2 we dont require voting.
+								: Boolean(hasVotedForElections.data && hasVotedForElections.data.hasVoted)
+						}
 						canClaim={delegateWallet ? delegateWallet.canClaim : canClaim}
 						hasClaimed={userStakingData.hasClaimed}
 						totalRewards={totalRewards}


### PR DESCRIPTION
Voting is not blocked on a contract level. And since voting is done on L1 I think it's fairly confusing to require voting on L2.
We also seem to have a bug that require users to reload after voting and going back to L2, this change should mean that users doesn't run in to this.