### PR TITLE
Allow empty flag numeric input

### DIFF
--- a/components/Input/NumericInput.tsx
+++ b/components/Input/NumericInput.tsx
@@ -10,11 +10,13 @@ type NumericInputProps = {
 	onChange: (e: ChangeEvent<HTMLInputElement>, value: string) => void;
 	className?: string;
 	disabled?: boolean;
+	allowEmpty?: boolean;
 };
 
 const INVALID_CHARS = ['-', '+', 'e'];
 
-const isValidNumber = (value: string) => {
+const isValidValue = (value: string, allowEmpty?: boolean) => {
+	if (allowEmpty && value === '') return true;
 	try {
 		FixedNumber.fromString(value);
 		return true;
@@ -28,11 +30,13 @@ const NumericInput: FC<NumericInputProps> = ({
 	onChange,
 	placeholder,
 	className,
+	allowEmpty,
 	...rest
 }) => {
 	const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
 		const { value } = e.target;
-		if (!isValidNumber(value)) return;
+		const valid = isValidValue(value, allowEmpty);
+		if (!valid) return;
 		onChange(e, value.replace(/,/g, '.').replace(/[e+-]/gi, ''));
 	};
 

--- a/sections/loans/components/ActionBox/BorrowSynthsTab/AssetInput.tsx
+++ b/sections/loans/components/ActionBox/BorrowSynthsTab/AssetInput.tsx
@@ -62,6 +62,7 @@ const AssetInput: React.FC<AssetInputProps> = ({
 	const amountInput = (
 		<AmountContainer>
 			<AmountInput
+				allowEmpty={true}
 				value={amount}
 				placeholder="0.00"
 				onChange={(e) => setAmount(e.target.value)}


### PR DESCRIPTION
Without this change you cant remove a an accidentally wrong value without special tricks. This feature makes the input work more how you expect an input to work. 

I didn't change it everywhere since Numeric input is used in a lot of places. 