### PR TITLE
Loans draw and cratio improvements

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -5,6 +5,7 @@ import { languageStateKey, priceCurrencyStateKey } from 'store/app/constants';
 
 import { CurrencyCategory, NetworkId, Synth } from '@synthetixio/contracts-interface';
 
+export const SYNTH_DECIMALS = 18;
 // app defaults
 export const DEFAULT_LANGUAGE: Language = localStore.get(languageStateKey) ?? Language.EN;
 export const DEFAULT_PRICE_CURRENCY: Synth = localStore.get(priceCurrencyStateKey) ?? {

--- a/containers/Loans/Loans.tsx
+++ b/containers/Loans/Loans.tsx
@@ -327,7 +327,6 @@ function Container() {
 		};
 		// eslint-disable-next-line
 	}, [ethLoanContract, address]);
-	console.log({ interactionDelays });
 	return {
 		loans,
 		isLoadingLoans,

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Close.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Close.tsx
@@ -7,6 +7,7 @@ import TransactionNotifier from 'containers/TransactionNotifier';
 import { tx } from 'utils/transactions';
 import Loans from 'containers/Loans';
 import Wrapper from './Wrapper';
+import ROUTES from 'constants/routes';
 
 type CloseProps = {
 	loanId: number;
@@ -46,7 +47,7 @@ const Close: React.FC<CloseProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 			await reloadPendingWithdrawals();
 			setIsWorking('');
 			setTxModalOpen(false);
-			router.push('/loans/list');
+			router.push(ROUTES.Loans.List);
 		} catch {
 			setIsWorking('');
 			setTxModalOpen(false);

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Deposit.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Deposit.tsx
@@ -7,6 +7,8 @@ import { Loan } from 'containers/Loans/types';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { tx } from 'utils/transactions';
 import Wrapper from './Wrapper';
+import { useRouter } from 'next/router';
+import ROUTES from 'constants/routes';
 
 type DepositProps = {
 	loanId: number;
@@ -23,6 +25,7 @@ const Deposit: React.FC<DepositProps> = ({
 	loanContract,
 	collateralAssetContract,
 }) => {
+	const router = useRouter();
 	const address = useRecoilValue(walletAddressState);
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 
@@ -121,6 +124,9 @@ const Deposit: React.FC<DepositProps> = ({
 						onTxConfirmed: () => {},
 					}),
 			});
+			setIsWorking('');
+			setTxModalOpen(false);
+			router.push(ROUTES.Loans.List);
 		} catch {
 		} finally {
 			setIsWorking('');

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Deposit.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Deposit.tsx
@@ -9,6 +9,9 @@ import { tx } from 'utils/transactions';
 import Wrapper from './Wrapper';
 import { useRouter } from 'next/router';
 import ROUTES from 'constants/routes';
+import { getRenBTCToken } from 'contracts/renBTCToken';
+import { getETHToken } from 'contracts/ethToken';
+import { SYNTH_DECIMALS } from 'constants/defaults';
 
 type DepositProps = {
 	loanId: number;
@@ -35,20 +38,23 @@ const Deposit: React.FC<DepositProps> = ({
 	const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
 
 	const collateralAsset = loanTypeIsETH ? 'ETH' : 'renBTC';
-	const collateralDecimals = loanTypeIsETH ? 18 : 8; // todo
+	const collateralDecimals = loanTypeIsETH ? getETHToken().decimals : getRenBTCToken().decimals; // todo
 
 	const [depositAmountString, setDepositalAmount] = useState<string | null>(null);
 	const collateralAmount = useMemo(
 		() =>
-			ethers.utils.parseUnits(ethers.utils.formatUnits(loan.collateral, 18), collateralDecimals), // normalize collateral decimals
+			ethers.utils.parseUnits(
+				ethers.utils.formatUnits(loan.collateral, collateralDecimals),
+				collateralDecimals
+			), // normalize collateral decimals
 		[loan.collateral, collateralDecimals]
 	);
 	const depositAmount = useMemo(
 		() =>
 			depositAmountString
-				? ethers.utils.parseUnits(depositAmountString, collateralDecimals)
+				? ethers.utils.parseUnits(depositAmountString, SYNTH_DECIMALS)
 				: ethers.BigNumber.from(0),
-		[depositAmountString, collateralDecimals]
+		[depositAmountString]
 	);
 
 	const totalAmount = useMemo(

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Draw.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Draw.tsx
@@ -4,25 +4,34 @@ import { Loan } from 'containers/Loans/types';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { tx } from 'utils/transactions';
 import Wrapper from './Wrapper';
+import useSynthetixQueries from '@synthetixio/queries';
+import { calculateLoanCRatio } from '../../BorrowSynthsTab/calculateLoanCRatio';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/router';
+import { calculateMaxDraw, getSafeCratio } from './helpers';
+import { wei } from '@synthetixio/wei';
 
-type RepayProps = {
+type DrawProps = {
 	loanId: number;
 	loanTypeIsETH: boolean;
 	loan: Loan;
 	loanContract: ethers.Contract;
 };
 
-const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract }) => {
+const Draw: React.FC<DrawProps> = ({ loan, loanId, loanTypeIsETH, loanContract }) => {
+	const router = useRouter();
 	const { monitorTransaction } = TransactionNotifier.useContainer();
-
+	const { t } = useTranslation();
 	const [isWorking, setIsWorking] = useState<string>('');
 	const [error, setError] = useState<string | null>(null);
 	const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
-	const [drawAmountString, setRepayAmount] = useState<string | null>(null);
+	const [drawAmountString, setDrawAmount] = useState<string | null>(null);
+	const { useExchangeRatesQuery } = useSynthetixQueries();
+	const exchangeRatesQuery = useExchangeRatesQuery();
+	const exchangeRates = exchangeRatesQuery.data ?? null;
 
 	const debtAsset = loan.currency;
 	const debtAssetDecimals = 18;
-
 	const drawAmount = useMemo(
 		() =>
 			drawAmountString
@@ -35,14 +44,27 @@ const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 		() => ethers.utils.formatUnits(newTotalAmount, debtAssetDecimals),
 		[newTotalAmount]
 	);
-
-	const onSetLeftColAmount = (amount: string) =>
-		!amount
-			? setRepayAmount(null)
-			: ethers.utils.parseUnits(amount, debtAssetDecimals).gt(loan.amount)
-			? onSetLeftColMaxAmount()
-			: setRepayAmount(amount);
-	const onSetLeftColMaxAmount = () => setRepayAmount(ethers.utils.formatUnits(loan.amount));
+	const safeCratio = getSafeCratio(loan);
+	const maxDrawUsd = calculateMaxDraw(loan, exchangeRates);
+	const onSetLeftColAmount = (amount: string) => {
+		if (!amount) {
+			setDrawAmount(null);
+			return;
+		}
+		const collateral = {
+			amount: wei(loan.collateral),
+			asset: loan.collateralAsset,
+		};
+		const newDebt = {
+			amount: wei(loan.amount).add(amount),
+			asset: loan.currency,
+		};
+		const newCratio = calculateLoanCRatio(exchangeRates, collateral, newDebt);
+		return newCratio.lt(safeCratio) ? onSetLeftColMaxAmount() : setDrawAmount(amount);
+	};
+	const onSetLeftColMaxAmount = () => {
+		setDrawAmount(maxDrawUsd.toString(2));
+	};
 
 	const getTxData = useCallback(() => {
 		if (!(loanContract && !drawAmount.eq(0))) return null;
@@ -62,6 +84,7 @@ const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 						onTxConfirmed: () => {},
 					}),
 			});
+			router.push('/loans/list');
 		} catch {
 		} finally {
 			setIsWorking('');
@@ -81,18 +104,18 @@ const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 				leftColLabel: 'loans.modify-loan.draw.left-col-label',
 				leftColAssetName: debtAsset,
 				leftColAmount: drawAmountString,
-				onSetLeftColAmount,
-				onSetLeftColMaxAmount,
+				onSetLeftColAmount: maxDrawUsd.eq(0) ? undefined : onSetLeftColAmount,
+				onSetLeftColMaxAmount: maxDrawUsd.eq(0) ? undefined : onSetLeftColMaxAmount,
 
 				rightColLabel: 'loans.modify-loan.draw.right-col-label',
 				rightColAssetName: debtAsset,
 				rightColAmount: newTotalAmountString,
 
 				buttonLabel: `loans.modify-loan.draw.button-labels.${isWorking ? isWorking : 'default'}`,
-				buttonIsDisabled: !!isWorking,
+				buttonIsDisabled: Boolean(isWorking) || maxDrawUsd.eq(0),
 				onButtonClick: draw,
 
-				error,
+				error: error ? error : maxDrawUsd.eq(0) ? t('loans.modify-loan.draw.low-collateral') : null,
 				setError,
 
 				txModalOpen,
@@ -102,4 +125,4 @@ const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 	);
 };
 
-export default Repay;
+export default Draw;

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Draw.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Draw.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
 import { calculateMaxDraw, getSafeCratio } from './helpers';
 import { wei } from '@synthetixio/wei';
+import ROUTES from 'constants/routes';
 
 type DrawProps = {
 	loanId: number;
@@ -84,9 +85,10 @@ const Draw: React.FC<DrawProps> = ({ loan, loanId, loanTypeIsETH, loanContract }
 						onTxConfirmed: () => {},
 					}),
 			});
-			router.push('/loans/list');
+			setIsWorking('');
+			setTxModalOpen(false);
+			router.push(ROUTES.Loans.List);
 		} catch {
-		} finally {
 			setIsWorking('');
 			setTxModalOpen(false);
 		}

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Draw.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Draw.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/router';
 import { calculateMaxDraw, getSafeCratio } from './helpers';
 import { wei } from '@synthetixio/wei';
 import ROUTES from 'constants/routes';
+import { SYNTH_DECIMALS } from 'constants/defaults';
 
 type DrawProps = {
 	loanId: number;
@@ -32,17 +33,16 @@ const Draw: React.FC<DrawProps> = ({ loan, loanId, loanTypeIsETH, loanContract }
 	const exchangeRates = exchangeRatesQuery.data ?? null;
 
 	const debtAsset = loan.currency;
-	const debtAssetDecimals = 18;
 	const drawAmount = useMemo(
 		() =>
 			drawAmountString
-				? ethers.utils.parseUnits(drawAmountString, debtAssetDecimals)
+				? ethers.utils.parseUnits(drawAmountString, SYNTH_DECIMALS)
 				: ethers.BigNumber.from(0),
 		[drawAmountString]
 	);
 	const newTotalAmount = useMemo(() => loan.amount.add(drawAmount), [loan.amount, drawAmount]);
 	const newTotalAmountString = useMemo(
-		() => ethers.utils.formatUnits(newTotalAmount, debtAssetDecimals),
+		() => ethers.utils.formatUnits(newTotalAmount, SYNTH_DECIMALS),
 		[newTotalAmount]
 	);
 	const safeCratio = getSafeCratio(loan);

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Repay.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Repay.tsx
@@ -9,6 +9,7 @@ import { tx } from 'utils/transactions';
 import Wrapper from './Wrapper';
 import { useRouter } from 'next/router';
 import ROUTES from 'constants/routes';
+import { SYNTH_DECIMALS } from 'constants/defaults';
 
 type RepayProps = {
 	loanId: number;
@@ -28,18 +29,17 @@ const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 	const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
 
 	const debtAsset = loan.currency;
-	const debtAssetDecimals = 18;
 
 	const repayAmount = useMemo(
 		() =>
 			repayAmountString
-				? ethers.utils.parseUnits(repayAmountString, debtAssetDecimals)
+				? ethers.utils.parseUnits(repayAmountString, SYNTH_DECIMALS)
 				: ethers.BigNumber.from(0),
 		[repayAmountString]
 	);
 	const remainingAmount = useMemo(() => loan.amount.sub(repayAmount), [loan.amount, repayAmount]);
 	const remainingAmountString = useMemo(
-		() => ethers.utils.formatUnits(remainingAmount, debtAssetDecimals),
+		() => ethers.utils.formatUnits(remainingAmount, SYNTH_DECIMALS),
 		[remainingAmount]
 	);
 	const isRepayingFully = useMemo(() => remainingAmount.eq(0), [remainingAmount]);
@@ -47,7 +47,7 @@ const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 	const onSetLeftColAmount = (amount: string) =>
 		!amount
 			? setRepayAmount(null)
-			: ethers.utils.parseUnits(amount, debtAssetDecimals).gt(loan.amount)
+			: ethers.utils.parseUnits(amount, SYNTH_DECIMALS).gt(loan.amount)
 			? onSetLeftColMaxAmount()
 			: setRepayAmount(amount);
 	const onSetLeftColMaxAmount = () => setRepayAmount(ethers.utils.formatUnits(loan.amount));

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Repay.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Repay.tsx
@@ -7,6 +7,8 @@ import { Loan } from 'containers/Loans/types';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { tx } from 'utils/transactions';
 import Wrapper from './Wrapper';
+import { useRouter } from 'next/router';
+import ROUTES from 'constants/routes';
 
 type RepayProps = {
 	loanId: number;
@@ -16,6 +18,7 @@ type RepayProps = {
 };
 
 const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract }) => {
+	const router = useRouter();
 	const address = useRecoilValue(walletAddressState);
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 
@@ -66,8 +69,10 @@ const Repay: React.FC<RepayProps> = ({ loan, loanId, loanTypeIsETH, loanContract
 						onTxConfirmed: () => {},
 					}),
 			});
+			setIsWorking('');
+			setTxModalOpen(false);
+			router.push(ROUTES.Loans.List);
 		} catch {
-		} finally {
 			setIsWorking('');
 			setTxModalOpen(false);
 		}

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Withdraw.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Withdraw.tsx
@@ -5,6 +5,8 @@ import TransactionNotifier from 'containers/TransactionNotifier';
 import { tx } from 'utils/transactions';
 import Loans from 'containers/Loans';
 import Wrapper from './Wrapper';
+import { useRouter } from 'next/router';
+import ROUTES from 'constants/routes';
 
 type WithdrawProps = {
 	loanId: number;
@@ -14,6 +16,7 @@ type WithdrawProps = {
 };
 
 const Withdraw: React.FC<WithdrawProps> = ({ loan, loanId, loanTypeIsETH, loanContract }) => {
+	const router = useRouter();
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const { reloadPendingWithdrawals } = Loans.useContainer();
 
@@ -73,8 +76,10 @@ const Withdraw: React.FC<WithdrawProps> = ({ loan, loanId, loanTypeIsETH, loanCo
 					}),
 			});
 			await reloadPendingWithdrawals();
+			setIsWorking('');
+			setTxModalOpen(false);
+			router.push(ROUTES.Loans.List);
 		} catch {
-		} finally {
 			setIsWorking('');
 			setTxModalOpen(false);
 		}

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Withdraw.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/Withdraw.tsx
@@ -7,6 +7,8 @@ import Loans from 'containers/Loans';
 import Wrapper from './Wrapper';
 import { useRouter } from 'next/router';
 import ROUTES from 'constants/routes';
+import { getETHToken } from 'contracts/ethToken';
+import { getRenBTCToken } from 'contracts/renBTCToken';
 
 type WithdrawProps = {
 	loanId: number;
@@ -26,11 +28,14 @@ const Withdraw: React.FC<WithdrawProps> = ({ loan, loanId, loanTypeIsETH, loanCo
 	const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
 
 	const collateralAsset = loanTypeIsETH ? 'ETH' : 'renBTC';
-	const collateralDecimals = loanTypeIsETH ? 18 : 8; // todo
+	const collateralDecimals = loanTypeIsETH ? getETHToken().decimals : getRenBTCToken().decimals;
 
 	const collateralAmount = useMemo(
 		() =>
-			ethers.utils.parseUnits(ethers.utils.formatUnits(loan.collateral, 18), collateralDecimals), // normalize collateral decimals
+			ethers.utils.parseUnits(
+				ethers.utils.formatUnits(loan.collateral, collateralDecimals),
+				collateralDecimals
+			), // normalize collateral decimals
 		[loan.collateral, collateralDecimals]
 	);
 	const withdrawalAmount = useMemo(

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/helpers.test.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/helpers.test.tsx
@@ -8,7 +8,7 @@ describe('calculateMaxDraw', () => {
 			collateralAsset: 'ETH',
 			currency: 'sUSD',
 			collateral: wei(1).toBN(),
-			amount: wei(1500).toBN(),
+			amount: wei(1600).toBN(),
 			minCratio: wei(1.3).toBN(),
 		} as any;
 		const exchangeRates = {
@@ -16,14 +16,14 @@ describe('calculateMaxDraw', () => {
 			[Synths.sUSD]: wei(1),
 		};
 		const result = calculateMaxDraw(loan, exchangeRates);
-		expect(result.toString(0)).toBe('500'); // 3000 / (1.3 + 0.2) - 1500
+		expect(result.toString(2)).toBe('542.86'); // 3000 / (1.3 + 0.1) - 1500
 	});
 	test('returns 0 if maxDraw is negative', () => {
 		const loan = {
 			collateralAsset: 'ETH',
 			currency: 'sUSD',
 			collateral: wei(1).toBN(),
-			amount: wei(2100).toBN(),
+			amount: wei(2500).toBN(),
 			minCratio: wei(1.3).toBN(),
 		} as any;
 		const exchangeRates = {
@@ -31,7 +31,7 @@ describe('calculateMaxDraw', () => {
 			[Synths.sUSD]: wei(1),
 		};
 		const result = calculateMaxDraw(loan, exchangeRates);
-		expect(result.toString(0)).toBe('0'); // 3000 / (1.3 + 0.2)
+		expect(result.toString(0)).toBe('0'); // 3000 / (1.3 + 0.1) - 2500 would be negative
 	});
 });
 
@@ -39,6 +39,6 @@ describe('getSafeCratio', () => {
 	test('works', () => {
 		const loan = { minCratio: wei(1.3) } as any;
 		const result = getSafeCratio(loan);
-		expect(result.toString(1)).toBe('1.5');
+		expect(result.toString(1)).toBe('1.4');
 	});
 });

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/helpers.test.tsx
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/helpers.test.tsx
@@ -1,0 +1,44 @@
+import { wei } from '@synthetixio/wei';
+import { Synths } from 'constants/currency';
+import { calculateMaxDraw, getSafeCratio } from './helpers';
+
+describe('calculateMaxDraw', () => {
+	test('works', () => {
+		const loan = {
+			collateralAsset: 'ETH',
+			currency: 'sUSD',
+			collateral: wei(1).toBN(),
+			amount: wei(1500).toBN(),
+			minCratio: wei(1.3).toBN(),
+		} as any;
+		const exchangeRates = {
+			[Synths.sETH]: wei(3000),
+			[Synths.sUSD]: wei(1),
+		};
+		const result = calculateMaxDraw(loan, exchangeRates);
+		expect(result.toString(0)).toBe('500'); // 3000 / (1.3 + 0.2) - 1500
+	});
+	test('returns 0 if maxDraw is negative', () => {
+		const loan = {
+			collateralAsset: 'ETH',
+			currency: 'sUSD',
+			collateral: wei(1).toBN(),
+			amount: wei(2100).toBN(),
+			minCratio: wei(1.3).toBN(),
+		} as any;
+		const exchangeRates = {
+			[Synths.sETH]: wei(3000),
+			[Synths.sUSD]: wei(1),
+		};
+		const result = calculateMaxDraw(loan, exchangeRates);
+		expect(result.toString(0)).toBe('0'); // 3000 / (1.3 + 0.2)
+	});
+});
+
+describe('getSafeCratio', () => {
+	test('works', () => {
+		const loan = { minCratio: wei(1.3) } as any;
+		const result = getSafeCratio(loan);
+		expect(result.toString(1)).toBe('1.5');
+	});
+});

--- a/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/helpers.ts
+++ b/sections/loans/components/ActionBox/ActiveBorrowsTab/ModifyLoanActions/helpers.ts
@@ -1,0 +1,27 @@
+import { wei } from '@synthetixio/wei';
+import { SAFE_MIN_CRATIO_BUFFER } from 'sections/loans/constants';
+import { getExchangeRatesForCurrencies } from 'utils/currencies';
+import { Synths } from 'constants/currency';
+import { Rates } from '@synthetixio/queries';
+import { Loan } from 'containers/Loans/types';
+
+export const getSafeCratio = (loan: Loan) => wei(loan.minCratio).add(SAFE_MIN_CRATIO_BUFFER);
+
+export const calculateMaxDraw = (loan: Loan, exchangeRates: Rates | null) => {
+	const collateralUSDPrice = getExchangeRatesForCurrencies(
+		exchangeRates,
+		loan.collateralAsset === 'renBTC' ? Synths.sBTC : Synths.sETH,
+		Synths.sUSD
+	);
+	const safeCratio = getSafeCratio(loan);
+	const maxUSDBasedOnLoan = wei(loan.collateral).mul(collateralUSDPrice).div(safeCratio);
+	const currentDebtUSDPrice = getExchangeRatesForCurrencies(
+		exchangeRates,
+		loan.currency,
+		Synths.sUSD
+	);
+	const usdValueOfCurrentDebt = currentDebtUSDPrice.mul(loan.amount);
+
+	const maxDraw = maxUSDBasedOnLoan.sub(usdValueOfCurrentDebt);
+	return maxDraw.lte(0) ? wei(0) : maxDraw;
+};

--- a/sections/loans/components/ActionBox/BorrowSynthsTab/AssetInput.tsx
+++ b/sections/loans/components/ActionBox/BorrowSynthsTab/AssetInput.tsx
@@ -74,7 +74,7 @@ const AssetInput: React.FC<AssetInputProps> = ({
 
 	const balanceLabel = (
 		<BalanceContainer>
-			<Balance {...{ asset, onSetMaxAmount }} />
+			<Balance asset={asset} onSetMaxAmount={onSetMaxAmount} />
 		</BalanceContainer>
 	);
 
@@ -190,6 +190,7 @@ const AmountInput = styled(NumericInput)`
 `;
 
 const BalanceContainer = styled.div`
+	min-height: 30px;
 	& > div {
 		${media.greaterThan('mdUp')`
 			margin-top: 14px;

--- a/sections/loans/components/ActionBox/BorrowSynthsTab/BorrowSynthsTab.tsx
+++ b/sections/loans/components/ActionBox/BorrowSynthsTab/BorrowSynthsTab.tsx
@@ -12,7 +12,7 @@ import {
 	ModalItemTitle as TxModalItemTitle,
 	ModalItemText as TxModalItemText,
 } from 'styles/common';
-import { DEBT_ASSETS, DEBT_ASSETS_L2, SAFE_MIN_CRATIO } from 'sections/loans/constants';
+import { DEBT_ASSETS, DEBT_ASSETS_L2, SAFE_MIN_CRATIO_BUFFER } from 'sections/loans/constants';
 import {
 	FormContainer,
 	InputsContainer,
@@ -148,7 +148,8 @@ const BorrowSynthsTab: FC<BorrowSynthsTabProps> = () => {
 	const debt = { amount: debtAmount, asset: debtAsset };
 	const collateral = { amount: collateralAmount, asset: collateralAsset };
 	const cratio = calculateLoanCRatio(exchangeRates, collateral, debt);
-	const hasLowCRatio = !collateralAmount.eq(0) && !debtAmount.eq(0) && cratio.lt(SAFE_MIN_CRATIO);
+	const safeMinCratio = minCRatio ? minCRatio.add(SAFE_MIN_CRATIO_BUFFER) : null;
+	const hasLowCRatio = !collateralAmount.eq(0) && !debtAmount.eq(0) && cratio.lt(safeMinCratio);
 	const hasInsufficientCollateral = collateralBalance.lt(minCollateralAmount);
 
 	const shouldOpenTransaction = Boolean(

--- a/sections/loans/components/ActionBox/components/CRatio.tsx
+++ b/sections/loans/components/ActionBox/components/CRatio.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { FlexDivRow, FlexDivRowCentered } from 'styles/common';
 import { formatPercent } from 'utils/formatters/number';
 import InfoSVG from 'sections/loans/components/ActionBox/components/InfoSVG';
-import { SAFE_MIN_CRATIO } from 'sections/loans/constants';
+import { SAFE_MIN_CRATIO_BUFFER } from 'sections/loans/constants';
 import Wei from '@synthetixio/wei';
 
 type CRatioProps = {
@@ -36,8 +36,8 @@ const CRatio: FC<CRatioProps> = ({ cratio, hasLowCRatio, minCRatio }) => {
 													: 'loans.tabs.new.healthy-cratio-tip'
 											}
 											values={{
-												minCRatio: minCRatio.toString(),
-												safeMinCRatio: SAFE_MIN_CRATIO,
+												minCRatio: formatPercent(minCRatio),
+												safeMinCRatio: formatPercent(minCRatio.add(SAFE_MIN_CRATIO_BUFFER)),
 											}}
 										/>
 									}

--- a/sections/loans/constants.ts
+++ b/sections/loans/constants.ts
@@ -10,7 +10,7 @@ export const COLLATERAL_ASSETS_L2 = ['ETH'];
 export const LOAN_TYPE_ERC20 = 'erc20';
 export const LOAN_TYPE_ETH = 'eth';
 
-export const SAFE_MIN_CRATIO = 1.5;
+export const SAFE_MIN_CRATIO_BUFFER = 0.2;
 
 export const SYNTH_BY_CURRENCY_KEY = {
 	[ethers.utils.formatBytes32String(Synths.sUSD)]: Synths.sUSD,

--- a/sections/loans/constants.ts
+++ b/sections/loans/constants.ts
@@ -10,7 +10,7 @@ export const COLLATERAL_ASSETS_L2 = ['ETH'];
 export const LOAN_TYPE_ERC20 = 'erc20';
 export const LOAN_TYPE_ETH = 'eth';
 
-export const SAFE_MIN_CRATIO_BUFFER = 0.2;
+export const SAFE_MIN_CRATIO_BUFFER = 0.1;
 
 export const SYNTH_BY_CURRENCY_KEY = {
 	[ethers.utils.formatBytes32String(Synths.sUSD)]: Synths.sUSD,

--- a/translations/en.json
+++ b/translations/en.json
@@ -710,8 +710,8 @@
 				"collateral": {
 					"label": "Using"
 				},
-				"low-cratio-tip": "You can only borrow at {{safeMinCRatio}}% or higher. Your position will be eligible for liquidation if it falls below {{minCRatio}}%.",
-				"healthy-cratio-tip": "Ensure your position stays above {{minCRatio}}% to prevent liquidation.",
+				"low-cratio-tip": "You can only borrow at {{safeMinCRatio}} or higher. Your position will be eligible for liquidation if it falls below {{minCRatio}}.",
+				"healthy-cratio-tip": "Ensure your position stays above {{minCRatio}} to prevent liquidation.",
 				"confirm-transaction": {
 					"left-panel-label": "BORROWING",
 					"right-panel-label": "POSTING"
@@ -786,6 +786,7 @@
 			"draw": {
 				"left-col-label": "INCREASE",
 				"right-col-label": "NEW TOTAL",
+				"low-collateral": "Collateral too low for adding more debt",
 				"button-labels": {
 					"default": "INCREASE DEBT",
 					"drawing": "INCREASING DEBT..."


### PR DESCRIPTION
- User safe cratio buffer rather than hardcoded safe c-ratio
 Fix Draw screen 
- Prevent user from adding more than max draw.
- Disable if you're below safe c-cratio
- Max button  now adds max debt to safe c-ratio (150%)