### PR TITLE
Dont auto reset pagination

### DIFF
--- a/sections/escrow/components/RewardEscrowSchedule/RewardEscrowSchedule.tsx
+++ b/sections/escrow/components/RewardEscrowSchedule/RewardEscrowSchedule.tsx
@@ -85,6 +85,7 @@ const RewardEscrowSchedule: React.FC = () => {
 								sortable: false,
 							},
 						]}
+						options={{ autoResetPage: false }}
 						data={schedule ? schedule.filter((e: any) => e.quantity.gt(0)) : []}
 						isLoading={escrowDataQuery.isLoading}
 						showPagination={true}


### PR DESCRIPTION
This fixes a bug where the vesting schedule table keeps reseting to the first page

Image from bug report:
![table-pagination-issue](https://user-images.githubusercontent.com/5688912/151136483-d7157cb8-5d71-47fd-ac4d-c4f012d40d2c.gif)

