### PR TITLE
Only enable burn transaction if we have an amount to burn

### DIFF
--- a/sections/staking/hooks/useBurnTx.ts
+++ b/sections/staking/hooks/useBurnTx.ts
@@ -114,7 +114,9 @@ const useBurnTx = () => {
 	});
 
 	const txn = useSynthetixTxn('Synthetix', burnCall[0], burnCall[1], gasPrice, {
-		enabled: burnType !== BurnActionType.CLEAR || !needToBuy || swapTxn.txnStatus === 'confirmed',
+		enabled:
+			(burnType !== BurnActionType.CLEAR || !needToBuy || swapTxn.txnStatus === 'confirmed') &&
+			Boolean(amountToBurnBN),
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
Avoids this error:

<img width="508" alt="Screen Shot 2022-03-14 at 9 37 32 am" src="https://user-images.githubusercontent.com/5688912/158195660-20a209f1-838b-4d56-adeb-135ec79b7f4a.png">

Reproduce by
1. Go to burning max 
2. Go back
3. Go to burn custom