### PR TITLE
[FEAT] Desktop sidebar: show tooltip info about total SNX staked

### DIFF
--- a/sections/shared/Layout/SideNav/DesktopSideNav.tsx
+++ b/sections/shared/Layout/SideNav/DesktopSideNav.tsx
@@ -76,10 +76,12 @@ const DesktopSideNav: FC = () => {
 					<CRatioBarStats />
 					<BalanceItem amount={snxBalance} currencyKey={CryptoCurrency.SNX} />
 					<BalanceItem amount={sUSDBalance} currencyKey={Synths.sUSD} />
-					<StyledTargetStakingRatio>
-						<StyledTargetStakingRatioTitle>Staking %</StyledTargetStakingRatioTitle>
-						{tRatio ? tRatio : '0.00'}%
-					</StyledTargetStakingRatio>
+					<Tooltip content={t('common.total-staking.staking-percentage')}>
+						<StyledTargetStakingRatio>
+							<StyledTargetStakingRatioTitle>Staking %</StyledTargetStakingRatioTitle>
+							{tRatio ? tRatio : '0.00'}%
+						</StyledTargetStakingRatio>
+					</Tooltip>
 					<Tooltip content={t('common.price-change.seven-days')}>
 						<PriceItemContainer>
 							<PriceItem currencyKey={CryptoCurrency.SNX} currencyRateChange={currencyRateChange} />

--- a/translations/en.json
+++ b/translations/en.json
@@ -1307,6 +1307,9 @@
 			"synthetic-currency-name": "Synthetic {{currencyName}}",
 			"deprecated": "deprecated"
 		},
+		"total-staking": {
+			"staking-percentage": "Total SNX staked"
+		},
 		"price-change": {
 			"seven-days": "7 days change"
 		},


### PR DESCRIPTION
# Description

<img width="122" alt="image" src="https://user-images.githubusercontent.com/160117/162577608-b1153182-0d3f-400c-af00-1e6cbca92c94.png">


I was confused about this number, and I believe more users could feel the same. Adding some clarity would help I believe.

This PR fixes that.

# Screenshot

<img width="155" alt="image" src="https://user-images.githubusercontent.com/160117/162577756-e33da4f5-7717-4335-a4c7-a1aaa5dcfc4b.png">
