### PR TITLE
Remove btc as a debt asset

### DIFF
--- a/sections/loans/constants.ts
+++ b/sections/loans/constants.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { Synths } from 'constants/currency';
 
-export const DEBT_ASSETS = ['sUSD', 'sETH', 'sBTC'];
+export const DEBT_ASSETS = ['sUSD', 'sETH'];
 export const DEBT_ASSETS_L2 = ['sUSD', 'sETH'];
 
 export const COLLATERAL_ASSETS = ['renBTC', 'ETH'];


### PR DESCRIPTION
This PR removes renBTC loans. Users should still be able to manage open loans
Closes https://github.com/Synthetixio/staking/issues/1014 