### PR TITLE
Perf updates

### DIFF
--- a/components/StatsSection/StatsSection.tsx
+++ b/components/StatsSection/StatsSection.tsx
@@ -24,14 +24,14 @@ import useCryptoBalances from 'hooks/useCryptoBalances';
 import { Tooltip } from 'styles/common';
 import { useTranslation } from 'react-i18next';
 import useGetCurrencyRateChange from 'hooks/useGetCurrencyRateChange';
+import { subDays, endOfHour } from 'date-fns';
 
 const StatsSection: FC = ({ children }) => {
 	const walletAddress = useRecoilValue(walletAddressState);
 	const delegateWallet = useRecoilValue(delegateWalletState);
 	const { t } = useTranslation();
 	const { useSynthsBalancesQuery } = useSynthetixQueries();
-
-	const sevenDaysAgoSeconds = Math.floor(new Date().setDate(new Date().getDate() - 7) / 1000);
+	const sevenDaysAgoSeconds = Math.floor(endOfHour(subDays(new Date(), 7)).getTime() / 1000);
 	const currencyRateChange = useGetCurrencyRateChange(sevenDaysAgoSeconds, 'SNX');
 
 	const cryptoBalances = useCryptoBalances(delegateWallet?.address ?? walletAddress);

--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -24,7 +24,7 @@ export const DEFAULT_GAS_BUFFER = 15000;
 
 // ui defaults
 export const DEFAULT_SEARCH_DEBOUNCE_MS = 300;
-export const DEFAULT_REQUEST_REFRESH_INTERVAL = 30000; // 30s
+export const DEFAULT_REQUEST_REFRESH_INTERVAL = 300000; // 5min
 export const DEFAULT_CRYPTO_DECIMALS = 4;
 export const DEFAULT_FIAT_DECIMALS = 2;
 export const DEFAULT_NUMBER_DECIMALS = 2;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -29,6 +29,7 @@ const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			refetchInterval: DEFAULT_REQUEST_REFRESH_INTERVAL,
+			refetchOnWindowFocus: false,
 		},
 	},
 });

--- a/sections/shared/Layout/SideNav/DesktopSideNav.tsx
+++ b/sections/shared/Layout/SideNav/DesktopSideNav.tsx
@@ -29,13 +29,14 @@ import useSynthetixQueries from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
 import useGetCurrencyRateChange from 'hooks/useGetCurrencyRateChange';
 import Connector from 'containers/Connector';
+import { endOfHour, subDays } from 'date-fns';
 
 const DesktopSideNav: FC = () => {
 	const walletAddress = useRecoilValue(walletAddressState);
 	const delegateWallet = useRecoilValue(delegateWalletState);
 	const { t } = useTranslation();
 	const { useSynthsBalancesQuery } = useSynthetixQueries();
-	const sevenDaysAgoSeconds = Math.floor(new Date().setDate(new Date().getDate() - 7) / 1000);
+	const sevenDaysAgoSeconds = Math.floor(endOfHour(subDays(new Date(), 7)).getTime() / 1000);
 	const currencyRateChange = useGetCurrencyRateChange(sevenDaysAgoSeconds, 'SNX');
 	const cryptoBalances = useCryptoBalances(delegateWallet?.address ?? walletAddress);
 	const synthsBalancesQuery = useSynthsBalancesQuery(delegateWallet?.address ?? walletAddress);


### PR DESCRIPTION
This PR adds three performance improvements
1. Change refetch interval to 5 min instead of every 30 sec.
 Queries will still update as you navigate around, we could even consider disable this

2. We dont need to refetch everytime the user focus the window
Making all queries refetch every time the window refocus is putting a lot of load on the app.
Instead of having this as a default for att queries it should be used specifically for queries that want this.
Most of the time I dont think it's needed since the data will update when user navigates around

3.  When calculating the 7day rate change use the end of hour price 7 days ago
The `sevenDaysAgoSeconds` gets passed to `subgraph.useGetRateUpdates`
The subgraph hooks pass all arguments as query keys. This meant we were constantly rerendering since the `now` timestamp kept changing