### PR TITLE
Only load loans data while on the loans page

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,7 +23,6 @@ import '@reach/dialog/styles.css';
 import 'tippy.js/dist/tippy.css';
 import '../i18n';
 import Connector from 'containers/Connector';
-import Loans from 'containers/Loans';
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -53,15 +52,13 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
 						  })
 				}
 			>
-				<Loans.Provider>
-					<Layout>
-						<SystemStatus>
-							<AppLayout>
-								<Component {...pageProps} />
-							</AppLayout>
-						</SystemStatus>
-					</Layout>
-				</Loans.Provider>
+				<Layout>
+					<SystemStatus>
+						<AppLayout>
+							<Component {...pageProps} />
+						</AppLayout>
+					</SystemStatus>
+				</Layout>
 				<ReactQueryDevtools />
 			</SynthetixQueryContextProvider>
 		</>

--- a/pages/loans/[[...action]].tsx
+++ b/pages/loans/[[...action]].tsx
@@ -17,6 +17,7 @@ import ActiveDebt from 'sections/shared/modals/DebtValueModal/DebtValueBox';
 import Main from 'sections/loans/index';
 import { useRecoilValue } from 'recoil';
 import { walletAddressState } from 'store/wallet';
+import Loans from 'containers/Loans';
 
 type LoansPageProps = {};
 
@@ -68,6 +69,14 @@ const LoansPage: FC<LoansPageProps> = () => {
 	);
 };
 
+const LoansWithContainer: FC<LoansPageProps> = (props) => {
+	return (
+		<Loans.Provider>
+			<LoansPage {...props} />
+		</Loans.Provider>
+	);
+};
+
 const Earning = styled(StatBox)`
 	.title {
 		color: ${(props) => props.theme.colors.green};
@@ -78,4 +87,4 @@ const Earning = styled(StatBox)`
 	}
 `;
 
-export default LoansPage;
+export default LoansWithContainer;


### PR DESCRIPTION
The loans page requires quite a lot of data when loading. When the `unstated` provider is mounted it triggers all the `useEffect`s in `container/Loans` to fire off. With this change we only let that happen when a user visits the Loans page