### PR TITLE
Staking reward tile

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
 		"prettier": "2.5.1",
 		"react-test-renderer": "^17.0.2",
 		"remarkable-external-link": "1.1.0",
+		"svg-jest": "1.0.1",
 		"typescript": "4.3.2",
 		"url-loader": "4.1.1",
 		"webp-loader": "0.6.0"
@@ -156,6 +157,13 @@
 		"setupFilesAfterEnv": [
 			"./test-setup/setup.js"
 		],
-		"testEnvironment": "jest-environment-jsdom"
+		"testEnvironment": "jest-environment-jsdom",
+		"transform": {
+			"\\.svg$": "svg-jest",
+			"\\.[jt]sx?$": "babel-jest"
+		},
+		"moduleNameMapper": {
+			"^.+\\.svg\\?(sprite|include)(.+)?$": "<rootDir>/test-setup/svgMock.js"
+		}
 	}
 }

--- a/sections/dashboard/PossibleActions/Layouts/LayoutDelegate.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutDelegate.tsx
@@ -16,21 +16,20 @@ import media from 'styles/media';
 
 import GridBox, { GridBoxProps } from 'components/GridBox/Gridbox';
 
-import { delegateWalletState, walletAddressState } from 'store/wallet';
+import { delegateWalletState } from 'store/wallet';
 import useUserStakingData from 'hooks/useUserStakingData';
 import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
 
 import { ActionsContainer as Container } from './common-styles';
 import { wei } from '@synthetixio/wei';
 
-const LayoutLayerOne: FC = () => {
+const LayoutDelegate: FC = () => {
 	const { t } = useTranslation();
 
-	const walletAddress = useRecoilValue(walletAddressState);
-
-	const { stakingRewards, tradingRewards } = useUserStakingData(walletAddress);
 	const { currentCRatio, targetCRatio } = useStakingCalculations();
 	const delegateWallet = useRecoilValue(delegateWalletState);
+	const liquidationRewardsQuery = useLiquidationRewards(delegateWallet?.address ?? null);
+	const { stakingRewards, tradingRewards } = useUserStakingData(delegateWallet?.address ?? null);
 
 	const gridItems: GridBoxProps[] = useMemo(() => {
 		const aboveTargetCRatio = currentCRatio.lte(targetCRatio);
@@ -112,4 +111,4 @@ const StyledContainer = styled(Container)`
 	`}
 `;
 
-export default LayoutLayerOne;
+export default LayoutDelegate;

--- a/sections/dashboard/PossibleActions/Layouts/LayoutDelegate.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutDelegate.tsx
@@ -8,7 +8,6 @@ import ROUTES from 'constants/routes';
 import { formatPercent } from 'utils/formatters/number';
 
 import MintIcon from 'assets/svg/app/mint.svg';
-import ClaimIcon from 'assets/svg/app/claim.svg';
 import BurnIcon from 'assets/svg/app/burn.svg';
 
 import { GlowingCircle } from 'styles/common';
@@ -22,6 +21,8 @@ import useStakingCalculations from 'sections/staking/hooks/useStakingCalculation
 
 import { ActionsContainer as Container } from './common-styles';
 import { wei } from '@synthetixio/wei';
+import useLiquidationRewards from 'hooks/useLiquidationRewards';
+import getSynthetixRewardTile from './getSynthetixRewardTile';
 
 const LayoutDelegate: FC = () => {
 	const { t } = useTranslation();
@@ -31,28 +32,17 @@ const LayoutDelegate: FC = () => {
 	const liquidationRewardsQuery = useLiquidationRewards(delegateWallet?.address ?? null);
 	const { stakingRewards, tradingRewards } = useUserStakingData(delegateWallet?.address ?? null);
 
+	const liquidationRewards = liquidationRewardsQuery.data ?? wei(0);
+	const stakingAndTradingRewards = stakingRewards.add(tradingRewards);
 	const gridItems: GridBoxProps[] = useMemo(() => {
 		const aboveTargetCRatio = currentCRatio.lte(targetCRatio);
 		return [
-			{
-				icon: (
-					<GlowingCircle variant="green" size="md">
-						<Svg
-							src={ClaimIcon}
-							width="32"
-							viewBox={`0 0 ${ClaimIcon.width} ${ClaimIcon.height}`}
-						/>
-					</GlowingCircle>
-				),
-				title: t('dashboard.actions.claim.title'),
-				copy: t('dashboard.actions.claim.copy'),
-				tooltip:
-					stakingRewards.eq(0) && tradingRewards.eq(0)
-						? t('dashboard.actions.claim.tooltip')
-						: undefined,
-				link: ROUTES.Earn.Claim,
-				isDisabled: (stakingRewards.eq(0) && tradingRewards.eq(0)) || !delegateWallet?.canClaim,
-			},
+			getSynthetixRewardTile(
+				t,
+				stakingAndTradingRewards,
+				liquidationRewards,
+				!delegateWallet?.canClaim
+			),
 			{
 				icon: (
 					<GlowingCircle variant={!aboveTargetCRatio ? 'orange' : 'blue'} size="md">
@@ -73,7 +63,16 @@ const LayoutDelegate: FC = () => {
 					(aboveTargetCRatio && !delegateWallet?.canMint),
 			},
 		].map((cell, i) => ({ ...cell, gridArea: `tile-${i + 1}` }));
-	}, [t, currentCRatio, targetCRatio, stakingRewards, tradingRewards, delegateWallet]);
+	}, [
+		t,
+		currentCRatio,
+		targetCRatio,
+		stakingAndTradingRewards,
+		liquidationRewards,
+		delegateWallet?.canClaim,
+		delegateWallet?.canBurn,
+		delegateWallet?.canMint,
+	]);
 
 	return (
 		<StyledContainer>

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
@@ -106,7 +106,7 @@ const LayoutLayerOne: FC = () => {
 				isDisabled: lpData[LP.CURVE_sUSD].APR.eq(0),
 			},
 		].map((cell, i) => ({ ...cell, gridArea: `tile-${i + 1}` }));
-	}, [t, lpData, currentCRatio, targetCRatio, stakingRewards, tradingRewards]);
+	}, [t, lpData, currentCRatio, targetCRatio, stakingAndTradingRewards, liquidationRewards]);
 
 	return (
 		<StyledContainer>

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
@@ -11,7 +11,6 @@ import { formatPercent } from 'utils/formatters/number';
 
 import KwentaIcon from 'assets/svg/app/kwenta.svg';
 import MintIcon from 'assets/svg/app/mint.svg';
-import ClaimIcon from 'assets/svg/app/claim.svg';
 import BurnIcon from 'assets/svg/app/burn.svg';
 
 import { GlowingCircle } from 'styles/common';
@@ -30,38 +29,24 @@ import { ActionsContainer as Container } from './common-styles';
 import { wei } from '@synthetixio/wei';
 import { useRecoilValue } from 'recoil';
 import { walletAddressState } from 'store/wallet';
+import getSynthetixRewardTile from './getSynthetixRewardTile';
+import useLiquidationRewards from 'hooks/useLiquidationRewards';
 
 const LayoutLayerOne: FC = () => {
 	const { t } = useTranslation();
 
 	const walletAddress = useRecoilValue(walletAddressState);
+	const liquidationRewardsQuery = useLiquidationRewards(walletAddress);
 
 	const lpData = useLPData();
 	const { stakingRewards, tradingRewards } = useUserStakingData(walletAddress);
 	const { currentCRatio, targetCRatio } = useStakingCalculations();
-
+	const liquidationRewards = liquidationRewardsQuery.data ?? wei(0);
+	const stakingAndTradingRewards = stakingRewards.add(tradingRewards);
 	const gridItems: GridBoxProps[] = useMemo(() => {
 		const aboveTargetCRatio = currentCRatio.lte(targetCRatio);
 		return [
-			{
-				icon: (
-					<GlowingCircle variant="green" size="md">
-						<Svg
-							src={ClaimIcon}
-							width="32"
-							viewBox={`0 0 ${ClaimIcon.width} ${ClaimIcon.height}`}
-						/>
-					</GlowingCircle>
-				),
-				title: t('dashboard.actions.claim.title'),
-				copy: t('dashboard.actions.claim.copy'),
-				tooltip:
-					stakingRewards.eq(0) && tradingRewards.eq(0)
-						? t('dashboard.actions.claim.tooltip')
-						: undefined,
-				link: ROUTES.Earn.Claim,
-				isDisabled: stakingRewards.eq(0) && tradingRewards.eq(0),
-			},
+			getSynthetixRewardTile(t, stakingAndTradingRewards, liquidationRewards),
 			{
 				icon: (
 					<GlowingCircle variant={!aboveTargetCRatio ? 'orange' : 'blue'} size="md">

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerTwo.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerTwo.tsx
@@ -10,7 +10,6 @@ import { formatPercent } from 'utils/formatters/number';
 
 import KwentaIcon from 'assets/svg/app/kwenta.svg';
 import MintIcon from 'assets/svg/app/mint.svg';
-import ClaimIcon from 'assets/svg/app/claim.svg';
 import BurnIcon from 'assets/svg/app/burn.svg';
 import SorbetFinance from 'assets/svg/app/sorbet-finance.svg';
 
@@ -30,11 +29,13 @@ import { useGetUniswapStakingRewardsAPY } from 'sections/pool/useGetUniswapStaki
 import { WETHSNXLPTokenContract } from 'constants/gelato';
 import { walletAddressState } from 'store/wallet';
 import Connector from 'containers/Connector';
-
+import useLiquidationRewards from 'hooks/useLiquidationRewards';
+import getSynthetixRewardTile from './getSynthetixRewardTile';
 const LayoutLayerTwo: FC = () => {
 	const { t } = useTranslation();
 
 	const walletAddress = useRecoilValue(walletAddressState);
+	const liquidationRewardsQuery = useLiquidationRewards(walletAddress);
 	const { synthetixjs } = Connector.useContainer();
 	const { stakingRewards, tradingRewards } = useUserStakingData(walletAddress);
 	const { currentCRatio, targetCRatio } = useStakingCalculations();
@@ -43,29 +44,13 @@ const LayoutLayerTwo: FC = () => {
 		stakingRewardsContract: synthetixjs?.contracts.StakingRewardsSNXWETHUniswapV3 ?? null,
 		tokenContract: WETHSNXLPTokenContract,
 	});
-
+	const liquidationRewards = liquidationRewardsQuery.data ?? wei(0);
+	const stakingAndTradingRewards = stakingRewards.add(tradingRewards);
 	const gridItems: GridBoxProps[] = useMemo(() => {
 		const aboveTargetCRatio = currentCRatio.lte(targetCRatio);
 		return [
-			{
-				icon: (
-					<GlowingCircle variant="green" size="md">
-						<Svg
-							src={ClaimIcon}
-							width="32"
-							viewBox={`0 0 ${ClaimIcon.width} ${ClaimIcon.height}`}
-						/>
-					</GlowingCircle>
-				),
-				title: t('dashboard.actions.claim.title'),
-				copy: t('dashboard.actions.claim.copy'),
-				tooltip:
-					stakingRewards.eq(0) && tradingRewards.eq(0)
-						? t('dashboard.actions.claim.tooltip')
-						: undefined,
-				link: ROUTES.Earn.Claim,
-				isDisabled: stakingRewards.eq(0) && tradingRewards.eq(0),
-			},
+			getSynthetixRewardTile(t, stakingAndTradingRewards, liquidationRewards),
+
 			{
 				icon: (
 					<GlowingCircle variant={!aboveTargetCRatio ? 'orange' : 'blue'} size="md">
@@ -106,7 +91,16 @@ const LayoutLayerTwo: FC = () => {
 				link: ROUTES.Pools.snx_weth,
 			},
 		].map((cell, i) => ({ ...cell, gridArea: `tile-${i + 1}` }));
-	}, [t, currentCRatio, targetCRatio, stakingRewards, tradingRewards, rates.data?.apy]);
+	}, [
+		t,
+		currentCRatio,
+		targetCRatio,
+		stakingAndTradingRewards,
+		liquidationRewards,
+		stakingRewards,
+		tradingRewards,
+		rates.data?.apy,
+	]);
 
 	return (
 		<StyledContainer>

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerTwo.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerTwo.tsx
@@ -97,8 +97,6 @@ const LayoutLayerTwo: FC = () => {
 		targetCRatio,
 		stakingAndTradingRewards,
 		liquidationRewards,
-		stakingRewards,
-		tradingRewards,
 		rates.data?.apy,
 	]);
 

--- a/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.test.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.test.tsx
@@ -1,0 +1,71 @@
+import { wei } from '@synthetixio/wei';
+import getSynthetixRewardTile from './getSynthetixRewardTile';
+
+describe('getSynthetixRewardTile', () => {
+	test('No staking rewards and have liq rewards', () => {
+		const t = jest.fn();
+		const stakingAndTradingRewards = wei(0);
+		const liquidationRewards = wei(100);
+		const result = getSynthetixRewardTile(t, stakingAndTradingRewards, liquidationRewards);
+		expect(result.link).toBe('/earn/liquidation');
+		expect(result.isDisabled).toBe(false);
+	});
+	test('Staking rewards and liq rewards', () => {
+		const t = jest.fn();
+		const stakingAndTradingRewards = wei(100);
+		const liquidationRewards = wei(100);
+		const result = getSynthetixRewardTile(t, stakingAndTradingRewards, liquidationRewards);
+		expect(result.link).toBe('/earn/claim');
+		expect(result.isDisabled).toBe(false);
+	});
+	test('No staking rewards and no liq rewards', () => {
+		const t = jest.fn();
+		const stakingAndTradingRewards = wei(0);
+		const liquidationRewards = wei(0);
+		const result = getSynthetixRewardTile(t, stakingAndTradingRewards, liquidationRewards);
+		expect(result.link).toBe('/earn/claim');
+		expect(result.isDisabled).toBe(true);
+	});
+	test('Have staking rewards, no liq rewards and delegate missing permission', () => {
+		const t = jest.fn();
+		const stakingAndTradingRewards = wei(100);
+		const liquidationRewards = wei(0);
+		const walletMissingPermissionToClaim = true;
+		const result = getSynthetixRewardTile(
+			t,
+			stakingAndTradingRewards,
+			liquidationRewards,
+			walletMissingPermissionToClaim
+		);
+		expect(result.link).toBe('/earn/claim');
+		expect(result.isDisabled).toBe(true);
+	});
+	test('No Staking rewards, have liq rewards and delegate missing permission', () => {
+		const t = jest.fn();
+		const stakingAndTradingRewards = wei(0);
+		const liquidationRewards = wei(100);
+		const walletMissingPermissionToClaim = true;
+		const result = getSynthetixRewardTile(
+			t,
+			stakingAndTradingRewards,
+			liquidationRewards,
+			walletMissingPermissionToClaim
+		);
+		expect(result.link).toBe('/earn/liquidation');
+		expect(result.isDisabled).toBe(false);
+	});
+	test('Have staking rewards, have liq rewards and delegate missing permission', () => {
+		const t = jest.fn();
+		const stakingAndTradingRewards = wei(100);
+		const liquidationRewards = wei(100);
+		const walletMissingPermissionToClaim = true;
+		const result = getSynthetixRewardTile(
+			t,
+			stakingAndTradingRewards,
+			liquidationRewards,
+			walletMissingPermissionToClaim
+		);
+		expect(result.link).toBe('/earn/liquidation');
+		expect(result.isDisabled).toBe(false);
+	});
+});

--- a/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.tsx
@@ -1,0 +1,47 @@
+import Wei from '@synthetixio/wei';
+import { Svg } from 'react-optimized-image';
+import { TFunction } from 'i18next';
+
+import { GlowingCircle } from 'styles/common';
+import ClaimIcon from 'assets/svg/app/claim.svg';
+import ROUTES from 'constants/routes';
+
+const getSynthetixRewardTile = (
+	t: TFunction,
+	stakingAndTradingRewards: Wei,
+	liquidationRewards: Wei,
+	walletMissingPermissionToClaim = false
+) => {
+	console.log(walletMissingPermissionToClaim);
+	// User have NO staking rewards and some liquidationRewards
+	// Link directly to Liquidation rewards
+	if (stakingAndTradingRewards.eq(0) && !liquidationRewards.eq(0)) {
+		return {
+			icon: (
+				<GlowingCircle variant="green" size="md">
+					<Svg src={ClaimIcon} width="32" viewBox={`0 0 ${ClaimIcon.width} ${ClaimIcon.height}`} />
+				</GlowingCircle>
+			),
+			title: t('dashboard.actions.claim.title'),
+			copy: t('dashboard.actions.claim.copy-liquidation'),
+			tooltip: undefined,
+			link: ROUTES.Earn.LIQUIDATION_REWARDS,
+			isDisabled: false,
+		};
+	}
+	// If we have staking rewards link to Claim
+	// If not, disable link and add show tooltip
+	return {
+		icon: (
+			<GlowingCircle variant="green" size="md">
+				<Svg src={ClaimIcon} width="32" viewBox={`0 0 ${ClaimIcon.width} ${ClaimIcon.height}`} />
+			</GlowingCircle>
+		),
+		title: t('dashboard.actions.claim.title'),
+		copy: t('dashboard.actions.claim.copy'),
+		tooltip: stakingAndTradingRewards.eq(0) ? t('dashboard.actions.claim.tooltip') : undefined,
+		link: ROUTES.Earn.Claim,
+		isDisabled: stakingAndTradingRewards.eq(0) || walletMissingPermissionToClaim,
+	};
+};
+export default getSynthetixRewardTile;

--- a/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/getSynthetixRewardTile.tsx
@@ -12,10 +12,13 @@ const getSynthetixRewardTile = (
 	liquidationRewards: Wei,
 	walletMissingPermissionToClaim = false
 ) => {
-	console.log(walletMissingPermissionToClaim);
-	// User have NO staking rewards and some liquidationRewards
-	// Link directly to Liquidation rewards
-	if (stakingAndTradingRewards.eq(0) && !liquidationRewards.eq(0)) {
+	const haveLiquidationRewards = !liquidationRewards.eq(0);
+	const noStakingRewardsAndHaveLiquidationRewards =
+		stakingAndTradingRewards.eq(0) && haveLiquidationRewards;
+	const missingPermissionAndHaveLiquidationRewards =
+		walletMissingPermissionToClaim && haveLiquidationRewards;
+
+	if (noStakingRewardsAndHaveLiquidationRewards || missingPermissionAndHaveLiquidationRewards) {
 		return {
 			icon: (
 				<GlowingCircle variant="green" size="md">

--- a/test-setup/svgMock.js
+++ b/test-setup/svgMock.js
@@ -1,0 +1,1 @@
+module.exports = () => null;

--- a/translations/en.json
+++ b/translations/en.json
@@ -183,6 +183,7 @@
 			"claim": {
 				"title": "CLAIM {{amount}} SNX",
 				"copy": "Claim your staking rewards before the end of this epoch",
+				"copy-liquidation": "Claim your liquidation rewards",
 				"tooltip": "No rewards to claim"
 			},
 			"mint": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13833,6 +13833,16 @@ jest-snapshot@^27.5.1:
     pretty-format "^27.5.1"
     semver "^7.3.2"
 
+jest-svg-transformer@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-svg-transformer/-/jest-svg-transformer-1.0.0.tgz#e38884ca4cd8b2295cdfa2a0b24667920c3a8a6d"
+  integrity sha1-44iEykzYsilc36KgskZnkgw6im0=
+
+jest-transform-stub@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz#19018b0851f7568972147a5d60074b55f0225a7d"
+  integrity sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==
+
 jest-util@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.1.tgz#3ba9771e8e31a0b85da48fe0b0891fb86c01c2f9"
@@ -19291,6 +19301,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+svg-jest@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/svg-jest/-/svg-jest-1.0.1.tgz#3a820280bfd4c1e0637d68c8d477d37d0ae46abb"
+  integrity sha512-uVbY14nW3IGXkRueduWpQNOVOvC0XE9uu3Y1MIWX6zgweOqPT+hmP/J92yCNBv5kAQzNU7DW2nCO+enZpv+Hsw==
 
 svg-parser@^2.0.2:
   version "2.0.4"


### PR DESCRIPTION
Make the claim rewards tile on the landing page a bit smarter.
See `getSynthetixRewardTile.test.tsx` for logic.

Also fixed some bugs for when in delegate mode.

