### PR TITLE
Liquidation rewards fix

### DIFF
--- a/sections/earn/LiquidationTab/LiquidationTab.tsx
+++ b/sections/earn/LiquidationTab/LiquidationTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-import Wei from '@synthetixio/wei';
+import Wei, { wei } from '@synthetixio/wei';
 import { Svg } from 'react-optimized-image';
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
@@ -92,7 +92,6 @@ const LiquidationTab: React.FC<LiquidationTabProps> = ({ liquidationRewards }) =
 		enabled: Boolean(addressToUse),
 		onSuccess: () => {
 			setTxModalOpen(false);
-			liquidationQuery.refetch();
 		},
 	});
 
@@ -195,6 +194,7 @@ const LiquidationTab: React.FC<LiquidationTabProps> = ({ liquidationRewards }) =
 							<DismissButton
 								variant="secondary"
 								onClick={() => {
+									liquidationQuery.refetch();
 									goToEarn();
 								}}
 							>

--- a/sections/earn/LiquidationTab/LiquidationTab.tsx
+++ b/sections/earn/LiquidationTab/LiquidationTab.tsx
@@ -74,8 +74,10 @@ const LiquidationTab: React.FC<LiquidationTabProps> = ({ liquidationRewards }) =
 	const walletAddress = useRecoilValue(walletAddressState);
 	const delegateWallet = useRecoilValue(delegateWalletState);
 	const addressToUse = delegateWallet?.address || walletAddress!;
-	const { useSynthetixTxn } = useSynthetixQueries();
+	const { useSynthetixTxn, useExchangeRatesQuery } = useSynthetixQueries();
 	const liquidationQuery = useLiquidationRewards(addressToUse);
+	const exchangeRatesQuery = useExchangeRatesQuery({ keepPreviousData: true });
+	const SNXRate = exchangeRatesQuery.data?.SNX ?? wei(0);
 
 	const { blockExplorerInstance } = Etherscan.useContainer();
 	const { selectedPriceCurrency, getPriceAtCurrentRate } = useSelectedPriceCurrency();
@@ -239,7 +241,7 @@ const LiquidationTab: React.FC<LiquidationTabProps> = ({ liquidationRewards }) =
 					<TotalValueWrapper>
 						<Subtext>{t('earn.incentives.options.liquidations.total-value')}</Subtext>
 						<Value>
-							{formatFiatCurrency(getPriceAtCurrentRate(liquidationRewards), {
+							{formatFiatCurrency(getPriceAtCurrentRate(liquidationRewards.mul(SNXRate)), {
 								sign: selectedPriceCurrency.sign,
 							})}
 						</Value>


### PR DESCRIPTION
- Make sure total value show the rewards in USD
- Dont refetch the query until the user clicks dismiss so that we show "claimed" correctly

Bug report:
![Screenshot_2022-05-23_at_11 51 09](https://user-images.githubusercontent.com/5688912/169805703-25bf9f17-3bf9-474b-b877-97f2bdbefa62.png)
![Screenshot_2022-05-23_at_11 47 03](https://user-images.githubusercontent.com/5688912/169805708-daacae85-d7bb-4e2a-84be-8a0c45486f58.png)
 