### PR TITLE
Self liq fixes

### DIFF
--- a/hooks/useLiquidationAmountToFixCollateral.ts
+++ b/hooks/useLiquidationAmountToFixCollateral.ts
@@ -3,7 +3,7 @@ import Connector from 'containers/Connector';
 import Wei, { wei } from '@synthetixio/wei';
 
 const useLiquidationAmountToFixCollateral = (
-	debtBalance: Wei,
+	debtBalance?: Wei,
 	collateralInUsd?: Wei,
 	selfLiquidationPenalty?: Wei,
 	liquidationPenalty?: Wei
@@ -15,13 +15,13 @@ const useLiquidationAmountToFixCollateral = (
 		async () => {
 			const amountToSelfLiquidateUsdP =
 				synthetixjs?.contracts.Liquidator.calculateAmountToFixCollateral(
-					debtBalance.toBN(),
+					debtBalance?.toBN(),
 					collateralInUsd?.toBN(),
 					selfLiquidationPenalty?.toBN()
 				);
 			const amountToLiquidateUsdP =
 				synthetixjs?.contracts.Liquidator.calculateAmountToFixCollateral(
-					debtBalance.toBN(),
+					debtBalance?.toBN(),
 					collateralInUsd?.toBN(),
 					liquidationPenalty?.toBN()
 				);
@@ -39,7 +39,8 @@ const useLiquidationAmountToFixCollateral = (
 					synthetixjs?.contracts &&
 					selfLiquidationPenalty &&
 					liquidationPenalty &&
-					collateralInUsd
+					collateralInUsd &&
+					debtBalance?.gt(0)
 			),
 		}
 	);

--- a/pages/staking/SelfLiquidation.tsx
+++ b/pages/staking/SelfLiquidation.tsx
@@ -159,14 +159,16 @@ const SelfLiquidation: React.FC<{
 	if (delegateWallet?.address) return null;
 	// Wait for data
 	if (liquidationData === undefined || liquidationAmountsToFixCollateral === undefined) return null;
+	// If c-ratio is 0 (user not staking) dont render self liquidation
+	if (isZero(currentCRatio)) return null;
+	// If liquidationRatio is set to zero I guess liquidation must be turned off
+	if (isZero(liquidationData.liquidationRatio)) return null;
 
 	const liquidationDeadlineForAccount = liquidationData.liquidationDeadlineForAccount;
 	const notBeenFlagged = liquidationDeadlineForAccount.eq(0);
 
-	const currentCratioPercent = wei(1).div(isZero(currentCRatio) ? 1 : currentCRatio); //0.3333333 = 3
-	const liquidationRatioPercent = wei(1).div(
-		isZero(liquidationData.liquidationRatio) ? 1 : liquidationData.liquidationRatio
-	); //0.6666 = 1.50
+	const currentCratioPercent = wei(1).div(currentCRatio); //0.3333333 = 3
+	const liquidationRatioPercent = wei(1).div(liquidationData.liquidationRatio); //0.6666 = 1.50
 	const currentCRatioBelowLiquidationCRatio = currentCratioPercent.gt(liquidationRatioPercent);
 	// Only render if flagged or below LiquidationCratio
 	if (notBeenFlagged && currentCRatioBelowLiquidationCRatio) return null;

--- a/pages/staking/SelfLiquidation.tsx
+++ b/pages/staking/SelfLiquidation.tsx
@@ -147,8 +147,13 @@ const SelfLiquidation: React.FC<{
 	);
 
 	const liquidationAmountsToFixCollateral = liquidationAmountsToFixCollateralQuery.data;
-
-	const txn = useSynthetixTxn('Synthetix', 'liquidateSelf');
+	const txn = useSynthetixTxn(
+		'Synthetix',
+		'liquidateSelf',
+		[],
+		{},
+		{ enabled: currentCRatio?.gt(0) }
+	);
 
 	// You cant self liquidate with delegation
 	if (delegateWallet?.address) return null;

--- a/pages/staking/SelfLiquidation.tsx
+++ b/pages/staking/SelfLiquidation.tsx
@@ -41,8 +41,10 @@ const SelfLiquidationText: React.FC<{
 	targetCRatio,
 }) => {
 	const nonEscrowedSNX = totalSNXBalance.sub(escrowedSnx);
-	const snxToBeSelfLiquidated = amountToBeSelfLiquidated.div(isZero(SNXRate) ? 1 : SNXRate);
-	const snxToBeLiquidated = amountOfNonSelfLiquidation.div(isZero(SNXRate) ? 1 : SNXRate);
+	// If SNX rate is 0 we need to wait for data
+	if (isZero(SNXRate)) return null;
+	const snxToBeSelfLiquidated = amountToBeSelfLiquidated.div(SNXRate);
+	const snxToBeLiquidated = amountOfNonSelfLiquidation.div(SNXRate);
 	const formatSNX = (amount: Wei) =>
 		formatCryptoCurrency(amount, {
 			currencyKey: 'SNX',

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -124,4 +124,4 @@ export function scale(input: Wei, decimalPlaces: number): Wei {
 	return input.mul(wei(10).pow(decimalPlaces));
 }
 
-export const isZero = (value: Wei) => value.toNumber() === 0;
+export const isZero = (value: Wei) => value.eq(0);


### PR DESCRIPTION
- If SNXRate is 0 we're loading
- Dont enable selfLiquidate call is c-ration is 0
- Dont render self liq ui is user not staking
- Dont try to estimate amount to fix collateral is debtbalance is 0
- Is zero should not convert to number incase there's overflow