### PR TITLE
Curve apys

### DIFF
--- a/hooks/useLPData.ts
+++ b/hooks/useLPData.ts
@@ -1,56 +1,38 @@
-import useCurveSusdPoolQuery from 'queries/liquidityPools/useCurveSusdPoolQuery';
+import useCurveSusdPoolQuery, { CurveData } from 'queries/liquidityPools/useCurveSusdPoolQuery';
 import useYearnSNXVaultQuery, {
 	YearnVaultData,
 } from 'queries/liquidityPools/useYearnSNXVaultQuery';
 
-import { WEEKS_IN_YEAR } from 'constants/date';
 import { DualRewardsLiquidityPoolData, LiquidityPoolData } from 'queries/liquidityPools/types';
 import { LP } from 'sections/earn/types';
-
-import useSynthetixQueries from '@synthetixio/queries';
 import Wei, { wei } from '@synthetixio/wei';
 
 type LPData = {
 	[name: string]: {
 		APR: Wei;
 		TVL: Wei;
-		data: LiquidityPoolData | DualRewardsLiquidityPoolData | YearnVaultData | undefined;
+		data:
+			| LiquidityPoolData
+			| DualRewardsLiquidityPoolData
+			| YearnVaultData
+			| CurveData['data']
+			| undefined;
 	};
 };
 
 const useLPData = (): LPData => {
-	const { useExchangeRatesQuery } = useSynthetixQueries();
-
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const SNXRate = exchangeRatesQuery.data?.SNX ?? 0;
 	const usesUSDPool = useCurveSusdPoolQuery();
 	const usesYearnSNXVault = useYearnSNXVaultQuery();
-
-	const sUsdTVL = usesUSDPool.isSuccess
-		? usesUSDPool.data!.balance.mul(usesUSDPool.data!.price)
-		: wei(0);
-	const sUsdAPR =
-		usesUSDPool.data?.distribution &&
-		SNXRate &&
-		sUsdTVL.gt(0) &&
-		usesUSDPool.data?.swapAPR &&
-		usesUSDPool.data?.rewardsAPR
-			? usesUSDPool.data.distribution
-					.mul(SNXRate)
-					.div(sUsdTVL)
-					.mul(WEEKS_IN_YEAR)
-					.add(usesUSDPool.data?.swapAPR)
-					.add(usesUSDPool.data?.rewardsAPR)
-			: wei(0);
-
+	const curveSusdPoolAPY = usesUSDPool.data?.APR ?? wei(0);
+	const curveSusdPoolTVL = usesUSDPool.data?.TVL ?? wei(0);
 	const yearnSNXVaultAPY = usesYearnSNXVault.data?.apy ?? wei(0);
 	const yearnSNXVaultTVL = usesYearnSNXVault.data?.tvl ?? wei(0);
 
 	return {
 		[LP.CURVE_sUSD]: {
-			APR: sUsdAPR,
-			TVL: sUsdTVL,
-			data: usesUSDPool.data,
+			APR: curveSusdPoolAPY,
+			TVL: curveSusdPoolTVL,
+			data: usesUSDPool.data?.data,
 		},
 		[LP.YEARN_SNX_VAULT]: {
 			APR: yearnSNXVaultAPY,

--- a/queries/liquidityPools/useCurveSusdPoolQuery.ts
+++ b/queries/liquidityPools/useCurveSusdPoolQuery.ts
@@ -5,11 +5,11 @@ import axios from 'axios';
 
 import Connector from 'containers/Connector';
 import {
-	curveGaugeController,
-	curveSusdGauge,
-	curveSusdPool,
 	curveSusdPoolToken,
 	curveSusdRewards,
+	curveSusdGauge,
+	curveSusdPool,
+	curveGaugeController,
 } from 'contracts';
 import QUERY_KEYS from 'constants/queryKeys';
 import { appReadyState } from 'store/app';
@@ -20,16 +20,191 @@ import {
 	isMainnetState,
 } from 'store/wallet';
 
-import { LiquidityPoolData } from './types';
-import { getCurveTokenPrice } from './helper';
 import Wei, { wei } from '@synthetixio/wei';
+import { getCurveTokenPrice } from './helper';
 
-export type CurveData = LiquidityPoolData & {
-	swapAPR: Wei;
-	rewardsAPR: Wei;
+export type CurveData = {
+	APR: Wei;
+	TVL: Wei;
+	data?: { duration: number; periodFinish: number; staked: Wei; rewards: Wei };
 };
 
-const useCurveSusdPoolQuery = (options?: UseQueryOptions<CurveData>) => {
+const curveApiUrls = {
+	mainnet: {
+		mainPoolsGaugeRewards: 'https://api.curve.fi/api/getMainPoolsGaugeRewards',
+		baseApys: 'https://api.curve.fi/api/getApys',
+	},
+	optimism: {
+		gaugeApys: 'https://api.curve.fi/api/getFactoGaugesCrvRewards/optimism',
+		baseApys: 'https://api.curve.fi/api/getFactoryAPYs-optimism',
+		poolData: 'https://api.curve.fi/api/getFactoryV2Pools-optimism',
+	},
+} as const;
+
+const calculateCRVAPYMainnet = (
+	curvePrice: Wei,
+	inflationRate: Wei,
+	relativeWeight: Wei,
+	workingSupply: Wei,
+	curveSusdVirtualPrice: Wei
+) => {
+	const SECONDS_IN_A_YEAR = 31536000;
+	/**
+	 * CRV rewards can be different depending on how long you lock your CRV. Without with this multiplier the calculation would assume max lock time / max rewards.
+	 * Applying 40% will target the lower range.
+	 * It's also worth noting that the calculation differ slightly compared to curve.fi UI.
+	 * At the time of writing this our calc gives back 2.79% whereas their UI says it 2.65%
+	 */
+	const multiplierForLowerRangeCRVRewards = 0.4;
+	const curveAPY = inflationRate
+		.mul(relativeWeight)
+		.mul(SECONDS_IN_A_YEAR)
+		.div(workingSupply)
+		.mul(multiplierForLowerRangeCRVRewards)
+		.div(curveSusdVirtualPrice)
+		.mul(curvePrice)
+		.mul(100) // convert decimal to percent
+		.toNumber();
+	return curveAPY;
+};
+const fetchMainnetData = async (walletAddress: string, provider: ethers.providers.Provider) => {
+	const curveSusdRewardsContract = new ethers.Contract(
+		curveSusdRewards.address,
+		curveSusdRewards.abi,
+		provider
+	);
+	const curveSusdPoolContract = new ethers.Contract(
+		curveSusdPool.address,
+		// @ts-ignore
+		curveSusdPool.abi,
+		provider as ethers.providers.Provider
+	);
+	const curveSusdPoolTokenContract = new ethers.Contract(
+		curveSusdPoolToken.address,
+		curveSusdPoolToken.abi,
+		provider
+	);
+	const curveSusdGaugeContract = new ethers.Contract(
+		curveSusdGauge.address,
+		// @ts-ignore
+		curveSusdGauge.abi,
+		provider
+	);
+	const curveGaugeControllerContract = new ethers.Contract(
+		curveGaugeController.address,
+		// @ts-ignore
+		curveGaugeController.abi,
+		provider
+	);
+	const POOL_NAME = 'susdv2';
+	try {
+		const mainPoolGaugeP = axios.get<{
+			data: { mainPoolsGaugeRewards: { [address: string]: { apy: number }[] } };
+		}>(curveApiUrls.mainnet.mainPoolsGaugeRewards);
+		const baseAPYP = axios.get<{ data: { susdv2: { baseApy: string } } }>(
+			curveApiUrls.mainnet.baseApys
+		);
+
+		const apiPromises = Promise.all([mainPoolGaugeP, baseAPYP]);
+		const contractPromises = Promise.all([
+			getCurveTokenPrice(),
+			curveSusdRewardsContract.DURATION(),
+			curveSusdRewardsContract.periodFinish(),
+			curveSusdGaugeContract.inflation_rate({ gasLimit: 1e5 }),
+			curveSusdGaugeContract.working_supply({ gasLimit: 1e5 }),
+			curveGaugeControllerContract.gauge_relative_weight(curveSusdGauge.address),
+			curveSusdPoolContract.get_virtual_price(),
+			curveSusdPoolTokenContract.balanceOf(curveSusdRewardsContract.address),
+			curveSusdGaugeContract.balanceOf(walletAddress),
+			curveSusdRewardsContract.earned(walletAddress),
+		]);
+
+		const [
+			[mainPoolGauge, baseAPY],
+			[
+				curvePrice,
+				duration,
+				periodFinish,
+				inflationRate,
+				workingSupply,
+				relativeWeight,
+				curveSusdVirtualPrice,
+				tvl,
+				staked,
+				rewards,
+			],
+		] = await Promise.all([apiPromises, contractPromises]);
+
+		const snxApy =
+			mainPoolGauge.data.data.mainPoolsGaugeRewards?.[curveSusdGauge.address.toLowerCase()][0]?.apy;
+		const baseApy = baseAPY.data.data?.[POOL_NAME]?.baseApy;
+
+		const curveAPY = calculateCRVAPYMainnet(
+			curvePrice,
+			wei(inflationRate),
+			wei(relativeWeight),
+			wei(workingSupply),
+			wei(curveSusdVirtualPrice)
+		);
+
+		if (snxApy === undefined || baseApy === undefined || curveAPY === undefined) return undefined;
+		return {
+			apy: Number(baseApy) + Number(snxApy) + Number(curveAPY),
+			tvl: wei(tvl).mul(curveSusdVirtualPrice).toNumber(),
+			data: {
+				periodFinish: Number(periodFinish) * 1000,
+				duration: Number(duration) * 1000,
+				staked: wei(staked),
+				rewards: wei(rewards),
+			},
+		};
+	} catch (error) {
+		console.log(error);
+		return undefined;
+	}
+};
+
+const CURVE_SUSD_POOL_ADDRESS_OPTIMISM = '0x061b87122ed14b9526a813209c8a59a633257bab';
+const fetchOptimismData = async () => {
+	try {
+		const CRVDataP = axios.get<{
+			data: { sideChainGaugesApys: { address: string; apy: string }[] };
+		}>(curveApiUrls.optimism.gaugeApys);
+		const baseAPYP = axios.get<{ data: { poolDetails: { poolAddress: string; apy: string }[] } }>(
+			curveApiUrls.optimism.baseApys
+		);
+		const poolDataP = axios.get<{ data: { poolData: { address: string; usdTotal: number }[] } }>(
+			curveApiUrls.optimism.poolData
+		);
+
+		const [CRVData, baseAPY, poolData] = await Promise.all([CRVDataP, baseAPYP, poolDataP]);
+
+		const poolDatum = poolData.data.data.poolData.find(
+			(x) => x.address.toLowerCase() === CURVE_SUSD_POOL_ADDRESS_OPTIMISM
+		);
+		const crvAPY = CRVData.data.data.sideChainGaugesApys.find(
+			(x) => x.address.toLowerCase() === CURVE_SUSD_POOL_ADDRESS_OPTIMISM
+		);
+
+		const poolDetails = baseAPY.data.data.poolDetails.find(
+			(x) => x.poolAddress.toLowerCase() === CURVE_SUSD_POOL_ADDRESS_OPTIMISM
+		);
+		const tvl = poolDatum?.usdTotal;
+		if (crvAPY?.apy === undefined || poolDetails?.apy === undefined || tvl === undefined) {
+			return undefined;
+		}
+		return {
+			apy: parseFloat(crvAPY.apy) + parseFloat(poolDetails.apy),
+			tvl: tvl,
+			data: undefined,
+		};
+	} catch (error) {
+		console.log(error);
+		return undefined;
+	}
+};
+
+const useCurveSusdPoolQuery = (options?: UseQueryOptions<CurveData | undefined>) => {
 	const isAppReady = useRecoilValue(appReadyState);
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const walletAddress = useRecoilValue(walletAddressState);
@@ -37,129 +212,23 @@ const useCurveSusdPoolQuery = (options?: UseQueryOptions<CurveData>) => {
 	const { provider } = Connector.useContainer();
 	const isMainnet = useRecoilValue(isMainnetState);
 
-	return useQuery<CurveData>(
+	return useQuery<CurveData | undefined>(
 		QUERY_KEYS.LiquidityPools.sUSD(walletAddress ?? '', network?.id!),
 		async () => {
-			const contract = new ethers.Contract(
-				curveSusdRewards.address,
-				curveSusdRewards.abi,
-				provider as ethers.providers.Provider
-			);
-			const curveSusdPoolContract = new ethers.Contract(
-				curveSusdPool.address,
-				// @ts-ignore
-				curveSusdPool.abi,
-				provider as ethers.providers.Provider
-			);
-			const curveSusdPoolTokenContract = new ethers.Contract(
-				curveSusdPoolToken.address,
-				// @ts-ignore
-				curveSusdPoolToken.abi,
-				provider as ethers.providers.Provider
-			);
-			const curveSusdGaugeContract = new ethers.Contract(
-				curveSusdGauge.address,
-				// @ts-ignore
-				curveSusdGauge.abi,
-				provider as ethers.providers.Provider
-			);
-			const curveGaugeControllerContract = new ethers.Contract(
-				curveGaugeController.address,
-				// @ts-ignore
-				curveGaugeController.abi,
-				provider as ethers.providers.Provider
-			);
+			const fetchData = isMainnet ? fetchMainnetData : fetchOptimismData;
 
-			const address = contract.address;
-			const getDuration = contract.DURATION || contract.rewardsDuration;
+			const { tvl, apy, data } = (await fetchData(walletAddress!, provider!)) || {};
 
-			const curveTokenPrice = getCurveTokenPrice();
-
-			const [
-				duration,
-				rate,
-				periodFinish,
-				curveSusdBalance,
-				curveSusdUserBalance,
-				curveSusdTokenPrice,
-				curveInflationRate,
-				curveWorkingSupply,
-				gaugeRelativeWeight,
-				curvePrice,
-				swapData,
-				curveRewards,
-				curveStaked,
-				curveAllowance,
-			] = await Promise.all([
-				getDuration(),
-				contract.rewardRate(),
-				contract.periodFinish(),
-				curveSusdPoolTokenContract.balanceOf(address),
-				curveSusdPoolTokenContract.balanceOf(walletAddress),
-				curveSusdPoolContract.get_virtual_price(),
-				curveSusdGaugeContract.inflation_rate({ gasLimit: 1e5 }),
-				curveSusdGaugeContract.working_supply({ gasLimit: 1e5 }),
-				curveGaugeControllerContract.gauge_relative_weight(curveSusdGauge.address),
-				curveTokenPrice,
-				axios.get('https://stats.curve.fi/raw-stats/apys.json'),
-				contract.earned(walletAddress),
-				curveSusdGaugeContract.balanceOf(walletAddress),
-				curveSusdPoolTokenContract.allowance(walletAddress, address),
-			]);
-
-			const durationInWeeks = Number(duration) / 3600 / 24 / 7;
-			const isPeriodFinished = new Date().getTime() > Number(periodFinish) * 1000;
-			const distribution = isPeriodFinished ? wei(0) : wei(rate).mul(duration).div(durationInWeeks);
-
-			const [
-				balance,
-				userBalance,
-				price,
-				inflationRate,
-				workingSupply,
-				relativeWeight,
-				rewards,
-				staked,
-				allowance,
-			] = [
-				curveSusdBalance,
-				curveSusdUserBalance,
-				curveSusdTokenPrice,
-				curveInflationRate,
-				curveWorkingSupply,
-				gaugeRelativeWeight,
-				curveRewards,
-				curveStaked,
-				curveAllowance,
-			].map((data) => wei(data));
-
-			const curveRate = inflationRate
-				.mul(relativeWeight)
-				.mul(31536000)
-				.div(workingSupply)
-				.mul(0.4)
-				.div(curveSusdTokenPrice);
-
-			const rewardsAPR = curveRate.mul(curvePrice);
-			const swapAPR = swapData?.data?.apy?.day?.susd ?? wei(0);
+			if (!apy || !tvl) return undefined;
 
 			return {
-				periodFinish: Number(periodFinish) * 1000,
-				distribution,
-				address,
-				price,
-				balance,
-				swapAPR,
-				rewardsAPR,
-				rewards,
-				staked,
-				duration: Number(duration) * 1000,
-				allowance,
-				userBalance,
+				TVL: wei(tvl),
+				APR: wei(apy / 100),
+				data,
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected && provider != null && isMainnet,
+			enabled: isAppReady && isWalletConnected && provider != null && Boolean(walletAddress),
 			...options,
 		}
 	);

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerOne.tsx
@@ -31,6 +31,7 @@ import { useRecoilValue } from 'recoil';
 import { walletAddressState } from 'store/wallet';
 import getSynthetixRewardTile from './getSynthetixRewardTile';
 import useLiquidationRewards from 'hooks/useLiquidationRewards';
+import { notNill } from 'utils/ts-helpers';
 
 const LayoutLayerOne: FC = () => {
 	const { t } = useTranslation();
@@ -83,7 +84,7 @@ const LayoutLayerOne: FC = () => {
 				copy: t('dashboard.actions.migrate.copy'),
 				link: ROUTES.L2.Home,
 			},
-			{
+			lpData[LP.CURVE_sUSD].APR && {
 				icon: (
 					<GlowingCircle variant="green" size="md">
 						<Currency.Icon
@@ -95,7 +96,7 @@ const LayoutLayerOne: FC = () => {
 					</GlowingCircle>
 				),
 				title: t('dashboard.actions.earn.title', {
-					percent: formatPercent(lpData[LP.CURVE_sUSD].APR, { minDecimals: 0 }),
+					percent: formatPercent(lpData[LP.CURVE_sUSD].APR, { minDecimals: 1 }),
 				}),
 				copy: t('dashboard.actions.earn.copy', {
 					asset: 'Curve sUSD Pool Token',
@@ -105,7 +106,9 @@ const LayoutLayerOne: FC = () => {
 				externalLink: ROUTES.Earn.sUSD_EXTERNAL,
 				isDisabled: lpData[LP.CURVE_sUSD].APR.eq(0),
 			},
-		].map((cell, i) => ({ ...cell, gridArea: `tile-${i + 1}` }));
+		]
+			.filter(notNill)
+			.map((cell, i) => ({ ...cell, gridArea: `tile-${i + 1}` }));
 	}, [t, lpData, currentCRatio, targetCRatio, stakingAndTradingRewards, liquidationRewards]);
 
 	return (

--- a/sections/dashboard/PossibleActions/Layouts/LayoutLayerTwo.tsx
+++ b/sections/dashboard/PossibleActions/Layouts/LayoutLayerTwo.tsx
@@ -11,7 +11,6 @@ import { formatPercent } from 'utils/formatters/number';
 import KwentaIcon from 'assets/svg/app/kwenta.svg';
 import MintIcon from 'assets/svg/app/mint.svg';
 import BurnIcon from 'assets/svg/app/burn.svg';
-import SorbetFinance from 'assets/svg/app/sorbet-finance.svg';
 
 import GridBox, { GridBoxProps } from 'components/GridBox/Gridbox';
 
@@ -25,25 +24,26 @@ import useStakingCalculations from 'sections/staking/hooks/useStakingCalculation
 import { ActionsContainer as Container } from './common-styles';
 import { wei } from '@synthetixio/wei';
 import { useRecoilValue } from 'recoil';
-import { useGetUniswapStakingRewardsAPY } from 'sections/pool/useGetUniswapStakingRewardsAPY';
-import { WETHSNXLPTokenContract } from 'constants/gelato';
 import { walletAddressState } from 'store/wallet';
-import Connector from 'containers/Connector';
 import useLiquidationRewards from 'hooks/useLiquidationRewards';
 import getSynthetixRewardTile from './getSynthetixRewardTile';
+import Currency from 'components/Currency';
+import { CryptoCurrency } from 'constants/currency';
+import { LP } from 'sections/earn/types';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
+import useLPData from 'hooks/useLPData';
+import { notNill } from 'utils/ts-helpers';
+
 const LayoutLayerTwo: FC = () => {
 	const { t } = useTranslation();
 
 	const walletAddress = useRecoilValue(walletAddressState);
 	const liquidationRewardsQuery = useLiquidationRewards(walletAddress);
-	const { synthetixjs } = Connector.useContainer();
 	const { stakingRewards, tradingRewards } = useUserStakingData(walletAddress);
 	const { currentCRatio, targetCRatio } = useStakingCalculations();
 
-	const rates = useGetUniswapStakingRewardsAPY({
-		stakingRewardsContract: synthetixjs?.contracts.StakingRewardsSNXWETHUniswapV3 ?? null,
-		tokenContract: WETHSNXLPTokenContract,
-	});
+	const lpData = useLPData();
+
 	const liquidationRewards = liquidationRewardsQuery.data ?? wei(0);
 	const stakingAndTradingRewards = stakingRewards.add(tradingRewards);
 	const gridItems: GridBoxProps[] = useMemo(() => {
@@ -78,27 +78,32 @@ const LayoutLayerTwo: FC = () => {
 				externalLink: EXTERNAL_LINKS.Trading.Kwenta,
 				isDisabled: false,
 			},
-			{
-				title: t('dashboard.actions.earn.title', {
-					percent: `${rates.data?.apy.toFixed(2) || '-'}%`,
-				}),
-				copy: t('dashboard.actions.earn.copy', { asset: 'WETH-SNX', supplier: 'Sorbet Finance' }),
+			lpData[LP.CURVE_sUSD].APR && {
 				icon: (
-					<GlowingCircle variant="purple" size="md">
-						<Svg src={SorbetFinance} width="32" />
+					<GlowingCircle variant="green" size="md">
+						<Currency.Icon
+							currencyKey={CryptoCurrency.CRV}
+							type={CurrencyIconType.TOKEN}
+							width="28"
+							height="28"
+						/>
 					</GlowingCircle>
 				),
-				link: ROUTES.Pools.snx_weth,
+				title: t('dashboard.actions.earn.title', {
+					percent: formatPercent(lpData[LP.CURVE_sUSD].APR, { minDecimals: 1 }),
+				}),
+				copy: t('dashboard.actions.earn.copy', {
+					asset: 'Curve sUSD Pool Token',
+					supplier: 'Curve Finance',
+				}),
+				tooltip: t('common.tooltip.external', { link: 'Curve Finance' }),
+				externalLink: ROUTES.Earn.sUSD_EXTERNAL,
+				isDisabled: lpData[LP.CURVE_sUSD].APR.eq(0),
 			},
-		].map((cell, i) => ({ ...cell, gridArea: `tile-${i + 1}` }));
-	}, [
-		t,
-		currentCRatio,
-		targetCRatio,
-		stakingAndTradingRewards,
-		liquidationRewards,
-		rates.data?.apy,
-	]);
+		]
+			.filter(notNill)
+			.map((cell, i) => ({ ...cell, gridArea: `tile-${i + 1}` }));
+	}, [currentCRatio, targetCRatio, t, stakingAndTradingRewards, liquidationRewards, lpData]);
 
 	return (
 		<StyledContainer>

--- a/sections/earn/IncentivesDefault.tsx
+++ b/sections/earn/IncentivesDefault.tsx
@@ -8,16 +8,19 @@ import { useRouter } from 'next/router';
 import ROUTES from 'constants/routes';
 import { CryptoCurrency } from 'constants/currency';
 import media from 'styles/media';
-import { isWalletConnectedState } from 'store/wallet';
+import { delegateWalletState, isWalletConnectedState } from 'store/wallet';
 import useFeePeriodTimeAndProgress from 'hooks/useFeePeriodTimeAndProgress';
 
 import IncentivesTable, { NOT_APPLICABLE } from './IncentivesTable';
 import ClaimTab from './ClaimTab';
 import LiquidationTab from './LiquidationTab';
-import { Tab } from './types';
+import { LP, Tab } from './types';
 import { DesktopOrTabletView } from 'components/Media';
 import useSynthetixQueries from '@synthetixio/queries';
 import Connector from 'containers/Connector';
+import useCurveSusdPoolQuery from 'queries/liquidityPools/useCurveSusdPoolQuery';
+import { notNill } from 'utils/ts-helpers';
+import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 
 type IncentivesProps = {
 	tradingRewards: Wei;
@@ -43,8 +46,10 @@ const Incentives: FC<IncentivesProps> = ({
 	const { t } = useTranslation();
 	const router = useRouter();
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+	const delegateWallet = useRecoilValue(delegateWalletState);
 	const { L1DefaultProvider } = Connector.useContainer();
 	const { useSNXData } = useSynthetixQueries();
+	const curvesUSDPoolQuery = useCurveSusdPoolQuery();
 
 	const lockedSnxQuery = useSNXData(L1DefaultProvider!);
 
@@ -62,7 +67,7 @@ const Incentives: FC<IncentivesProps> = ({
 				: null,
 		[router.query.pool, isWalletConnected]
 	);
-
+	const curveData = curvesUSDPoolQuery.data;
 	const incentives = useMemo(
 		() =>
 			isWalletConnected
@@ -104,20 +109,46 @@ const Incentives: FC<IncentivesProps> = ({
 							tab: Tab.LIQUIDATION_REWARDS,
 							neverExpires: true,
 						},
-				  ]
+						// This component in used for both delegate wallets and optimism, we only want curve incentives to show up for non delegated wallets
+						!delegateWallet?.address && curveData !== undefined
+							? {
+									title: t('earn.incentives.options.curve.title'),
+									subtitle: t('earn.incentives.options.curve.subtitle'),
+									apr: curveData.APR,
+									tvl: curveData.TVL,
+									staked: {
+										balance: undefined,
+										asset: CryptoCurrency.CRV,
+										ticker: LP.CURVE_sUSD,
+										type: CurrencyIconType.TOKEN,
+									},
+									rewards: undefined,
+									periodStarted: 0,
+									periodFinish: Number.MAX_SAFE_INTEGER,
+									claimed: NOT_APPLICABLE,
+									now,
+									route: ROUTES.Earn.sUSD_LP,
+									tab: Tab.sUSD_LP,
+									externalLink: ROUTES.Earn.sUSD_EXTERNAL,
+									neverExpires: true,
+							  }
+							: undefined,
+				  ].filter(notNill)
 				: [],
 		[
-			stakingAPR,
-			stakedAmount,
-			lockedSnxQuery.data?.lockedValue,
-			nextFeePeriodStarts,
-			stakingRewards,
-			hasClaimed,
-			currentFeePeriodStarted,
-			now,
-			t,
 			isWalletConnected,
+			t,
+			stakingAPR,
+			lockedSnxQuery.data?.lockedValue,
+			stakedAmount,
+			stakingRewards,
+			currentFeePeriodStarted,
+			nextFeePeriodStarts,
+			hasClaimed,
+			now,
 			liquidationRewards,
+			delegateWallet?.address,
+			curveData,
 		]
 	);
 

--- a/sections/earn/IncentivesMainnet.tsx
+++ b/sections/earn/IncentivesMainnet.tsx
@@ -23,6 +23,7 @@ import { YearnVaultData } from 'queries/liquidityPools/useYearnSNXVaultQuery';
 import useSynthetixQueries from '@synthetixio/queries';
 import Connector from 'containers/Connector';
 import LiquidationTab from './LiquidationTab';
+import { notNill } from 'utils/ts-helpers';
 
 enum View {
 	ACTIVE = 'active',
@@ -136,27 +137,29 @@ const Incentives: FC<IncentivesProps> = ({
 						neverExpires: true,
 					},
 
-					{
-						title: t('earn.incentives.options.curve.title'),
-						subtitle: t('earn.incentives.options.curve.subtitle'),
-						apr: lpData[LP.CURVE_sUSD].APR,
-						tvl: lpData[LP.CURVE_sUSD].TVL,
-						staked: {
-							balance: lpData[LP.CURVE_sUSD].data?.staked ?? wei(0),
-							asset: CryptoCurrency.CRV,
-							ticker: LP.CURVE_sUSD,
-							type: CurrencyIconType.TOKEN,
-						},
-						rewards: lpData[LP.CURVE_sUSD].data?.rewards ?? wei(0),
-						periodStarted: now - (lpData[LP.CURVE_sUSD].data?.duration ?? 0),
-						periodFinish: lpData[LP.CURVE_sUSD].data?.periodFinish ?? 0,
-						claimed: (lpData[LP.CURVE_sUSD].data?.rewards ?? 0) > 0 ? false : NOT_APPLICABLE,
-						now,
-						route: ROUTES.Earn.sUSD_LP,
-						tab: Tab.sUSD_LP,
-						externalLink: ROUTES.Earn.sUSD_EXTERNAL,
-					},
-			  ]
+					Boolean(lpData[LP.CURVE_sUSD].TVL && lpData[LP.CURVE_sUSD].APR)
+						? {
+								title: t('earn.incentives.options.curve.title'),
+								subtitle: t('earn.incentives.options.curve.subtitle'),
+								apr: lpData[LP.CURVE_sUSD].APR,
+								tvl: lpData[LP.CURVE_sUSD].TVL,
+								staked: {
+									balance: lpData[LP.CURVE_sUSD].data?.staked ?? wei(0),
+									asset: CryptoCurrency.CRV,
+									ticker: LP.CURVE_sUSD,
+									type: CurrencyIconType.TOKEN,
+								},
+								rewards: lpData[LP.CURVE_sUSD].data?.rewards ?? wei(0),
+								periodStarted: now - (lpData[LP.CURVE_sUSD].data?.duration ?? 0),
+								periodFinish: lpData[LP.CURVE_sUSD].data?.periodFinish ?? 0,
+								claimed: NOT_APPLICABLE,
+								now,
+								route: ROUTES.Earn.sUSD_LP,
+								tab: Tab.sUSD_LP,
+								externalLink: ROUTES.Earn.sUSD_EXTERNAL,
+						  }
+						: undefined,
+			  ].filter(notNill)
 			: [];
 	}, [
 		stakingAPR,
@@ -181,10 +184,10 @@ const Incentives: FC<IncentivesProps> = ({
 					? incentives.filter((e) => e.periodFinish > Date.now())
 					: incentives.filter((e) => e.periodFinish <= Date.now())
 			}
-			isLoaded={!!lpData[LP.CURVE_sUSD].data}
+			isLoaded={!!lpData[LP.CURVE_sUSD].APR}
 		/>
 	);
-
+	const yearnLpData = lpData[LP.YEARN_SNX_VAULT].data;
 	return activeTab == null ? (
 		<>
 			<TabList noOfTabs={2}>
@@ -235,9 +238,11 @@ const Incentives: FC<IncentivesProps> = ({
 				)}
 				{activeTab === Tab.yearn_SNX_VAULT && (
 					<YearnVaultTab
-						userBalance={lpData[LP.YEARN_SNX_VAULT].data?.userBalance ?? wei(0)}
+						userBalance={
+							yearnLpData && 'userBalance' in yearnLpData ? yearnLpData.userBalance : wei(0)
+						}
 						stakedAsset={CryptoCurrency.SNX}
-						allowance={lpData[LP.YEARN_SNX_VAULT].data?.allowance ?? null}
+						allowance={yearnLpData && 'allowance' in yearnLpData ? yearnLpData.allowance : null}
 						tokenRewards={lpData[LP.YEARN_SNX_VAULT].data?.rewards ?? wei(0)}
 						staked={lpData[LP.YEARN_SNX_VAULT].data?.staked ?? wei(0)}
 						pricePerShare={

--- a/sections/earn/IncentivesTable.tsx
+++ b/sections/earn/IncentivesTable.tsx
@@ -53,12 +53,12 @@ export type EarnItem = {
 	apr?: Wei;
 	tvl: Wei;
 	staked: {
-		balance: Wei;
+		balance?: Wei;
 		asset: CurrencyKey;
 		ticker: CurrencyKey;
 		type?: CurrencyIconType;
 	};
-	rewards: Wei | DualRewards;
+	rewards?: Wei | DualRewards;
 	periodStarted: number;
 	periodFinish: number;
 	claimed: boolean | string;
@@ -148,20 +148,23 @@ const IncentivesTable: FC<IncentivesTableProps> = ({ data, isLoaded, activeTab }
 			{
 				Header: <>{t('earn.incentives.options.staked-balance.title')}</>,
 				accessor: 'staked.balance',
-				Cell: (cellProps: CellProps<EarnItem, EarnItem['staked']['balance']>) => (
-					<CellContainer>
-						<Title isNumeric={true}>
-							{formatCurrency(
-								cellProps.row.original.staked.ticker,
-								cellProps.row.original.staked.balance,
-								{
-									currencyKey: cellProps.row.original.staked.ticker,
-								}
-							)}
-						</Title>
-						<Subtitle />
-					</CellContainer>
-				),
+				Cell: (cellProps: CellProps<EarnItem, EarnItem['staked']['balance']>) => {
+					if (cellProps.row.original.staked.balance === undefined) return '-';
+					return (
+						<CellContainer>
+							<Title isNumeric={true}>
+								{formatCurrency(
+									cellProps.row.original.staked.ticker,
+									cellProps.row.original.staked.balance,
+									{
+										currencyKey: cellProps.row.original.staked.ticker,
+									}
+								)}
+							</Title>
+							<Subtitle />
+						</CellContainer>
+					);
+				},
 				width: 150,
 				sortable: true,
 			},
@@ -185,6 +188,9 @@ const IncentivesTable: FC<IncentivesTableProps> = ({ data, isLoaded, activeTab }
 				Header: <>{t('earn.incentives.options.rewards.title')}</>,
 				accessor: 'rewards',
 				Cell: (cellProps: CellProps<EarnItem, EarnItem['rewards']>) => {
+					if (!cellProps.row.original.rewards) {
+						return '-';
+					}
 					const isDualRewards = cellProps.row.original.dualRewards;
 					if (
 						!cellProps.row.original.externalLink ||


### PR DESCRIPTION
- Update `curveSusdPoolQuery` to support optimism and use API when available. This makes the results more similiar to what we see on curve.fu
- Make sure we display curve data for both optimism and mainnet, both on the landing page and on the /earn page.
- Optimism also had the G-UNI pool removed

Landing page optimism:
![Screen Shot 2022-05-25 at 1 51 38 pm](https://user-images.githubusercontent.com/5688912/170175967-05323ba4-76c7-48e2-9e19-5596f1141b9a.png)

Landing page mainnet:
![Screen Shot 2022-05-25 at 1 51 28 pm](https://user-images.githubusercontent.com/5688912/170176016-9d5af076-4049-4f21-81e9-35f6c32e0efe.png)

Earn page mainnet:
![Screen Shot 2022-05-25 at 1 51 14 pm](https://user-images.githubusercontent.com/5688912/170176060-07ac533e-f708-49f4-ad27-e447481b4925.png)

Earn page optimism
![Screen Shot 2022-05-25 at 2 18 31 pm](https://user-images.githubusercontent.com/5688912/170178806-b8687e22-a951-45d3-8e93-46d5e9a4551b.png)


