### PR TITLE
Self liquidate icon

### DIFF
--- a/components/StructuredTab/StructuredTab.tsx
+++ b/components/StructuredTab/StructuredTab.tsx
@@ -11,7 +11,7 @@ export type TabInfo = {
 	icon?: ReactNode;
 	tabChildren: ReactNode;
 	key: string;
-	blue: boolean;
+	color?: string;
 	disabled?: boolean;
 };
 
@@ -46,12 +46,12 @@ const StructuredTab: FC<StructuredTabProps> = ({
 
 	const desktop = () => (
 		<TabList noOfTabs={tabData.length}>
-			{tabData.map(({ title, icon, key, blue, disabled = false }, index) => (
+			{tabData.map(({ title, icon, key, color, disabled = false }, index) => (
 				<TabButton
 					isSingle={singleTab}
 					tabHeight={tabHeight}
 					inverseTabColor={inverseTabColor}
-					blue={blue}
+					color={color}
 					key={`${key}-${index}-button`}
 					name={title}
 					active={activeTab === key}

--- a/components/Tab/Tab.tsx
+++ b/components/Tab/Tab.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import styled, { css } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 
 import { resetButtonCSS } from 'styles/common';
 
@@ -8,24 +8,28 @@ type TabButtonProps = {
 	active: boolean;
 	onClick?: () => void;
 	children: ReactNode;
-	blue: boolean;
+	color?: string;
 	tabHeight?: number;
 	inverseTabColor?: boolean;
 	isSingle?: boolean;
 	isDisabled?: boolean;
 };
 
-export const TabButton = (props: TabButtonProps) => (
-	<StyledTabButton
-		id={`${props.name}-tab`}
-		role="tab"
-		aria-selected={props.active}
-		aria-controls={`${props.name}-tabpanel`}
-		tabIndex={-1}
-		isDisabled={props.isDisabled}
-		{...props}
-	/>
-);
+export const TabButton = (props: TabButtonProps) => {
+	const theme = useTheme();
+	return (
+		<StyledTabButton
+			id={`${props.name}-tab`}
+			role="tab"
+			aria-selected={props.active}
+			aria-controls={`${props.name}-tabpanel`}
+			tabIndex={-1}
+			isDisabled={props.isDisabled}
+			color={props.color || theme.colors.blue}
+			{...props}
+		/>
+	);
+};
 
 export const TabList = ({ children, ...props }: { children: ReactNode; noOfTabs: number }) => (
 	<StyledTabList {...props}>{children}</StyledTabList>
@@ -88,23 +92,11 @@ const StyledTabButton = styled.button<TabButtonProps>`
 
 	${(props) =>
 		props.active
-			? props.blue
-				? css`
-						border-top: ${`2px solid ${props.theme.colors.blue}`};
-						border-right: ${`1px solid ${props.theme.colors.grayBlue}`};
-						border-left: ${`1px solid ${props.theme.colors.backgroundBlue}`};
-						border-bottom: ${`1px solid ${props.theme.colors.backgroundBlue}`};
-				  `
-				: css`
-						border-top: ${`2px solid ${props.theme.colors.orange}`};
-						border-left: ${`1px solid ${props.theme.colors.grayBlue}`};
-						border-right: ${`1px solid ${props.theme.colors.backgroundBlue}`};
-						border-bottom: ${`1px solid ${props.theme.colors.backgroundBlue}`};
-				  `
-			: props.blue
 			? css`
-					border-top: ${`2px solid ${props.theme.colors.black}`};
-					border-bottom: ${`1px solid ${props.theme.colors.grayBlue}`};
+					border-top: ${`2px solid ${props.color || props.theme.colors.blue}`};
+					border-right: ${`1px solid ${props.theme.colors.grayBlue}`};
+					border-left: ${`1px solid ${props.theme.colors.backgroundBlue}`};
+					border-bottom: ${`1px solid ${props.theme.colors.backgroundBlue}`};
 			  `
 			: css`
 					border-top: ${`2px solid ${props.theme.colors.black}`};
@@ -127,17 +119,10 @@ const StyledTabButton = styled.button<TabButtonProps>`
 
 
 	&:hover {
-		color: ${(props) =>
-			props.active
-				? props.theme.colors.white
-				: props.blue
-				? props.theme.colors.blue
-				: props.theme.colors.orange};
+		color: ${(props) => (props.active ? props.theme.colors.white : props.color)};
 		background: ${(props) =>
 			props.inverseTabColor ? props.theme.colors.black : props.theme.colors.backgroundBlue};
-		border-top: 2px solid
-			${(props) =>
-				props.active ? 'none' : props.blue ? props.theme.colors.blue : props.theme.colors.orange};
+		border-top: 2px solid ${(props) => (props.active ? 'none' : props.color)};
 	}
 
 	height: ${(props) => (props.tabHeight ? `${props.tabHeight}px` : '60px')};

--- a/sections/debt/Debt.tsx
+++ b/sections/debt/Debt.tsx
@@ -16,13 +16,11 @@ const DebtSection = () => {
 			{
 				title: t('debt.actions.track.title'),
 				tabChildren: <OverviewTab />,
-				blue: true,
 				key: DebtPanelType.OVERVIEW,
 			},
 			{
 				title: t('debt.actions.manage.title'),
 				tabChildren: <ManageTab />,
-				blue: true,
 				key: DebtPanelType.MANAGE,
 				width: 450,
 			},

--- a/sections/debt/components/DebtTabs/index.tsx
+++ b/sections/debt/components/DebtTabs/index.tsx
@@ -87,7 +87,6 @@ const DebtTabs: FC<DebtTabsProps> = ({
 								<TabButton
 									isSingle={false}
 									tabHeight={tabHeight}
-									blue={true}
 									key={`${key}-${index}-button`}
 									name={title}
 									active={activeTab === key}

--- a/sections/delegate/DelegateForm.tsx
+++ b/sections/delegate/DelegateForm.tsx
@@ -44,7 +44,6 @@ const DelegateForm: FC = () => {
 				title: t('delegate.form.title'),
 				tabChildren: <Tab />,
 				key: 'main',
-				blue: true,
 			},
 		],
 		[t]

--- a/sections/earn/IncentivesMainnet.tsx
+++ b/sections/earn/IncentivesMainnet.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo, useState } from 'react';
 import Wei, { wei } from '@synthetixio/wei';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 import { useRouter } from 'next/router';
@@ -52,6 +52,7 @@ const Incentives: FC<IncentivesProps> = ({
 }) => {
 	const { t } = useTranslation();
 	const router = useRouter();
+	const theme = useTheme();
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const [view, setView] = useState<View>(View.ACTIVE);
 	const { L1DefaultProvider } = Connector.useContainer();
@@ -192,7 +193,7 @@ const Incentives: FC<IncentivesProps> = ({
 					isSingle={false}
 					tabHeight={50}
 					inverseTabColor={true}
-					blue={true}
+					color={theme.colors.blue}
 					key={`active-button`}
 					name={t('earn.tab.active')}
 					active={view === View.ACTIVE}
@@ -206,7 +207,7 @@ const Incentives: FC<IncentivesProps> = ({
 					isSingle={false}
 					tabHeight={50}
 					inverseTabColor={true}
-					blue={false}
+					color={theme.colors.orange}
 					key={`inactive-button`}
 					name={t('earn.tab.inactive')}
 					active={view === View.INACTIVE}

--- a/sections/earn/LPTab/YearnVaultTab.tsx
+++ b/sections/earn/LPTab/YearnVaultTab.tsx
@@ -32,7 +32,7 @@ import {
 	HeaderLabel,
 } from '../common';
 
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 import { MobileOnlyView } from 'components/Media';
 import DepositTab from './DepositTab/DepositTab';
@@ -66,6 +66,7 @@ const YearnVaultTab: FC<LPTabProps> = ({
 	pricePerShare,
 }) => {
 	const { t } = useTranslation();
+	const theme = useTheme();
 	const [showApproveOverlayModal, setShowApproveOverlayModal] = useState<boolean>(false);
 
 	const [claimTransactionState, setClaimTransactionState] = useState<Transaction>(
@@ -89,13 +90,13 @@ const YearnVaultTab: FC<LPTabProps> = ({
 			{
 				title: t('earn.actions.deposit.title'),
 				tabChildren: <DepositTab {...commonDepositTabProps} isDeposit={true} />,
-				blue: true,
+				color: theme.colors.blue,
 				key: 'deposit',
 			},
 			{
 				title: t('earn.actions.withdraw.title'),
 				tabChildren: <DepositTab {...commonDepositTabProps} isDeposit={false} />,
-				blue: false,
+				color: theme.colors.orange,
 				key: 'withdraw',
 			},
 		];

--- a/sections/escrow/components/ActionBox.tsx
+++ b/sections/escrow/components/ActionBox.tsx
@@ -8,6 +8,7 @@ import { EscrowPanelType } from 'store/escrow';
 import TokenSaleTab from './TokenSaleTab';
 import { useRouter } from 'next/router';
 import { isL2State } from 'store/wallet';
+import { useTheme } from 'styled-components';
 
 type ActionBoxProps = {
 	currentTab: string;
@@ -17,24 +18,24 @@ const ActionBox: React.FC<ActionBoxProps> = ({ currentTab }) => {
 	const { t } = useTranslation();
 	const router = useRouter();
 	const isL2 = useRecoilValue(isL2State);
-
+	const theme = useTheme();
 	const tabData = useMemo(
 		() => [
 			{
 				title: t('escrow.actions.staking.title'),
 				tabChildren: <StakingRewardsTab />,
 				key: EscrowPanelType.REWARDS,
-				blue: true,
+				color: theme.colors.blue,
 			},
 			{
 				title: t('escrow.actions.ico.title'),
 				tabChildren: <TokenSaleTab />,
 				key: EscrowPanelType.ICO,
 				disabled: isL2,
-				blue: false,
+				color: theme.colors.orange,
 			},
 		],
-		[t, isL2]
+		[t, theme.colors.blue, theme.colors.orange, isL2]
 	);
 
 	return (

--- a/sections/gov/components/Panel.tsx
+++ b/sections/gov/components/Panel.tsx
@@ -80,31 +80,26 @@ const Panel: React.FC<PanelProps> = ({ currentTab }) => {
 			{
 				title: t('gov.panel.proposals.title'),
 				tabChildren: <List spaceKey={activeTab} />,
-				blue: true,
 				key: SPACE_KEY.PROPOSAL,
 			},
 			{
 				title: t('gov.panel.council.title'),
 				tabChildren: <List spaceKey={activeTab} />,
-				blue: true,
 				key: SPACE_KEY.COUNCIL,
 			},
 			{
 				title: t('gov.panel.treasury-council.title'),
 				tabChildren: <List spaceKey={activeTab} />,
-				blue: true,
 				key: SPACE_KEY.TREASURY,
 			},
 			{
 				title: t('gov.panel.grants.title'),
 				tabChildren: <List spaceKey={activeTab} />,
-				blue: true,
 				key: SPACE_KEY.GRANTS,
 			},
 			{
 				title: t('gov.panel.ambassador.title'),
 				tabChildren: <List spaceKey={activeTab} />,
-				blue: true,
 				key: SPACE_KEY.AMBASSADOR,
 			},
 		],

--- a/sections/gov/components/Proposal/Info.tsx
+++ b/sections/gov/components/Proposal/Info.tsx
@@ -27,7 +27,6 @@ const Info: React.FC<InfoProps> = ({ proposal }) => {
 			{
 				title: t('gov.proposal.votes.title'),
 				tabChildren: <Results proposalResults={proposalResults} hash={proposal.id} />,
-				blue: true,
 				key: ProposalInfoType.RESULTS,
 			},
 			{
@@ -35,7 +34,6 @@ const Info: React.FC<InfoProps> = ({ proposal }) => {
 					count: proposalResults.data?.voteList.length ?? undefined,
 				}),
 				tabChildren: <History proposalResults={proposalResults} hash={proposal.id} />,
-				blue: true,
 				key: ProposalInfoType.HISTORY,
 			},
 		],

--- a/sections/layer2/migrate/ActionBox/ActionBox.tsx
+++ b/sections/layer2/migrate/ActionBox/ActionBox.tsx
@@ -6,14 +6,12 @@ import MigrateTab from '../MigrateTab';
 
 const ActionBox: React.FC = () => {
 	const { t } = useTranslation();
-
 	const tabData = useMemo(
 		() => [
 			{
 				title: t('layer2.actions.migrate.title'),
 				tabChildren: <MigrateTab />,
 				key: 'migrate',
-				blue: true,
 			},
 		],
 		[t]

--- a/sections/loans/components/ActionBox/ActionBox.tsx
+++ b/sections/loans/components/ActionBox/ActionBox.tsx
@@ -37,7 +37,6 @@ const ActionBox: React.FC<ActionBoxProps> = () => {
 				title: t('loans.tabs.new.title'),
 				tabChildren: <BorrowSynthsTab />,
 				key: 'new',
-				blue: true,
 			},
 			{
 				title: t('loans.tabs.list.title'),
@@ -48,7 +47,6 @@ const ActionBox: React.FC<ActionBoxProps> = () => {
 					/>
 				),
 				key: 'list',
-				blue: true,
 			},
 		],
 		[t, loanId, loanAction, loanType]

--- a/sections/merge-accounts/burn/BurnActionBox.tsx
+++ b/sections/merge-accounts/burn/BurnActionBox.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, FC, useCallback } from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { Trans, useTranslation } from 'react-i18next';
 import { Svg } from 'react-optimized-image';
 import { useRouter } from 'next/router';
@@ -50,7 +50,6 @@ const BurnTab: FC = () => {
 				title: t('merge-accounts.burn.title'),
 				tabChildren: <BurnTabInner />,
 				key: 'main',
-				blue: true,
 			},
 		],
 		[t]

--- a/sections/merge-accounts/merge/MergeActionBox.tsx
+++ b/sections/merge-accounts/merge/MergeActionBox.tsx
@@ -45,7 +45,6 @@ const MergeTab: FC = () => {
 				title: t('merge-accounts.merge.title'),
 				tabChildren: <MergeTabInner />,
 				key: 'main',
-				blue: true,
 			},
 		],
 		[t]

--- a/sections/merge-accounts/nominate/NominateActionBox.tsx
+++ b/sections/merge-accounts/nominate/NominateActionBox.tsx
@@ -40,14 +40,12 @@ import { TxWaiting, TxSuccess } from './Tx';
 
 const NominateTab: FC = () => {
 	const { t } = useTranslation();
-
 	const tabData = useMemo(
 		() => [
 			{
 				title: t('merge-accounts.nominate.title'),
 				tabChildren: <NominateTabInner />,
 				key: 'main',
-				blue: true,
 			},
 		],
 		[t]

--- a/sections/pool/TabsButton/index.tsx
+++ b/sections/pool/TabsButton/index.tsx
@@ -2,6 +2,7 @@ import StructuredTab from 'components/StructuredTab';
 
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTheme } from 'styled-components';
 import PoolTab, { PoolTabProps } from '../Tab';
 
 type PoolTabsProps = Omit<PoolTabProps, 'action' | 'stakingRewardsContractName'>;
@@ -14,6 +15,7 @@ export default function PoolTabs({
 	stakedTokens,
 }: PoolTabsProps) {
 	const { t } = useTranslation();
+	const theme = useTheme();
 	const tabData = useMemo(
 		() => [
 			{
@@ -29,7 +31,7 @@ export default function PoolTabs({
 						stakingRewardsContractName={'StakingRewardsSNXWETHUniswapV3'}
 					/>
 				),
-				blue: true,
+				color: theme.colors.blue,
 				key: 'Add Liquidity',
 			},
 			{
@@ -45,11 +47,20 @@ export default function PoolTabs({
 						stakingRewardsContractName={'StakingRewardsSNXWETHUniswapV3'}
 					/>
 				),
-				blue: false,
+				color: theme.colors.orange,
 				key: 'Remove Liquidity',
 			},
 		],
-		[t, balance, rewardsToClaim, allowanceAmount, stakedTokens, fetchBalances]
+		[
+			t,
+			balance,
+			rewardsToClaim,
+			allowanceAmount,
+			stakedTokens,
+			fetchBalances,
+			theme.colors.blue,
+			theme.colors.orange,
+		]
 	);
 	return <StructuredTab boxPadding={40} boxHeight={450} tabData={tabData} />;
 }

--- a/sections/staking/components/ActionBox.tsx
+++ b/sections/staking/components/ActionBox.tsx
@@ -10,6 +10,7 @@ import BurnTab from './BurnTab';
 import MintTab from './MintTab';
 import Burn from 'assets/svg/app/burn.svg';
 import Mint from 'assets/svg/app/mint.svg';
+import Warning from 'assets/svg/app/warning.svg';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { burnTypeState, StakingPanelType, mintTypeState } from 'store/staking';
 import SelfLiquidateTab from './SelfLiquidateTab';
@@ -90,7 +91,7 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 				showSelfLiquidationTab
 					? {
 							title: 'Self Liquidate',
-							icon: <Svg src={Burn} />,
+							icon: <Svg width={38} height={49} src={Warning} />,
 							tabChildren: <SelfLiquidateTab />,
 							color: theme.colors.pink,
 							key: StakingPanelType.SELF_LIQUIDATE,

--- a/sections/staking/components/ActionBox.tsx
+++ b/sections/staking/components/ActionBox.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, FC, useEffect } from 'react';
 import { Svg } from 'react-optimized-image';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
+import { useTheme } from 'styled-components';
 
 import StructuredTab from 'components/StructuredTab';
 
@@ -33,6 +34,7 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 	const walletAddress = useRecoilValue(walletAddressState);
 	const delegateWallet = useRecoilValue(delegateWalletState);
 	const { useSynthsBalancesQuery } = useSynthetixQueries();
+	const theme = useTheme();
 
 	const {
 		percentageCurrentCRatio,
@@ -75,14 +77,14 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 					title: t('staking.actions.mint.title'),
 					icon: <Svg src={Mint} />,
 					tabChildren: <MintTab />,
-					blue: true,
+					color: theme.colors.blue,
 					key: StakingPanelType.MINT,
 				},
 				{
 					title: t('staking.actions.burn.title'),
 					icon: <Svg src={Burn} />,
 					tabChildren: <BurnTab />,
-					blue: false,
+					color: theme.colors.orange,
 					key: StakingPanelType.BURN,
 				},
 				showSelfLiquidationTab
@@ -90,12 +92,12 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 							title: 'Self Liquidate',
 							icon: <Svg src={Burn} />,
 							tabChildren: <SelfLiquidateTab />,
-							blue: false,
+							color: theme.colors.pink,
 							key: StakingPanelType.SELF_LIQUIDATE,
 					  }
 					: undefined,
 			].filter(notNill),
-		[showSelfLiquidationTab, t]
+		[showSelfLiquidationTab, t, theme.colors.blue, theme.colors.orange, theme.colors.pink]
 	);
 
 	return (


### PR DESCRIPTION
- Changes the tab component so we can pass in `color` rather than `blue:true`.  Most tabs to use `blue:true` so I also made the default color blue.
- Add warning icon for self liquidation tab 

![Screen Shot 2022-05-27 at 4 53 04 pm](https://user-images.githubusercontent.com/5688912/170648901-d39821ec-c1dd-4779-a66e-07e4daba32e5.png)

