### PR TITLE
Self liquidation tab ux improvements

### DIFF
--- a/components/SelfLiquidateTransactionButton.tsx
+++ b/components/SelfLiquidateTransactionButton.tsx
@@ -24,6 +24,7 @@ const SelfLiquidateTransactionButton: React.FC<{
 	return (
 		<>
 			<Button
+				data-testid="self-liquidate-btn"
 				disabled={disabled}
 				variant={'primary'}
 				onClick={() => {

--- a/hooks/useGetSnxAmountToBeLiquidatedUsd.ts
+++ b/hooks/useGetSnxAmountToBeLiquidatedUsd.ts
@@ -6,7 +6,8 @@ const useGetSnxAmountToBeLiquidatedUsd = (
 	debtBalance?: Wei,
 	collateralInUsd?: Wei,
 	selfLiquidationPenalty?: Wei,
-	liquidationPenalty?: Wei
+	liquidationPenalty?: Wei,
+	enabled?: boolean
 ) => {
 	const { network, synthetixjs } = Connector.useContainer();
 
@@ -38,7 +39,8 @@ const useGetSnxAmountToBeLiquidatedUsd = (
 		},
 		{
 			enabled: Boolean(
-				network?.id &&
+				enabled &&
+					network?.id &&
 					synthetixjs?.contracts &&
 					selfLiquidationPenalty &&
 					liquidationPenalty &&

--- a/pages/staking/SelfLiquidation.tsx
+++ b/pages/staking/SelfLiquidation.tsx
@@ -109,14 +109,14 @@ const CratioUnderLiquidationRatioWarning: React.FC<{
 
 const SelfLiquidation: React.FC<{
 	percentageTargetCRatio: Wei;
-	currentCRatio: Wei;
+	percentageCurrentCRatio: Wei;
 	totalSNXBalance: Wei;
 	debtBalance: Wei;
 	escrowedSnx: Wei;
 	SNXRate: Wei;
 }> = ({
 	percentageTargetCRatio,
-	currentCRatio,
+	percentageCurrentCRatio,
 	totalSNXBalance,
 	escrowedSnx,
 	SNXRate,
@@ -144,16 +144,15 @@ const SelfLiquidation: React.FC<{
 	// Wait for data
 	if (liquidationData === undefined || snxAmountToBeLiquidatedUsd === undefined) return null;
 	// If c-ratio is 0 (user not staking) dont render self liquidation
-	if (isZero(currentCRatio)) return null;
+	if (isZero(percentageCurrentCRatio)) return null;
 	// If liquidationRatio is set to zero I guess liquidation must be turned off
 	if (isZero(liquidationData.liquidationRatio)) return null;
 
 	const liquidationDeadlineForAccount = liquidationData.liquidationDeadlineForAccount;
 	const notBeenFlagged = liquidationDeadlineForAccount.eq(0);
 
-	const currentCratioPercent = wei(1).div(currentCRatio); //0.3333333 = 3
 	const liquidationRatioPercent = wei(1).div(liquidationData.liquidationRatio); //0.6666 = 1.50
-	const currentCRatioBelowLiquidationCRatio = currentCratioPercent.gt(liquidationRatioPercent);
+	const currentCRatioBelowLiquidationCRatio = percentageCurrentCRatio.gt(liquidationRatioPercent);
 	// Only render if flagged or below LiquidationCratio
 	if (notBeenFlagged && currentCRatioBelowLiquidationCRatio) return null;
 
@@ -163,7 +162,7 @@ const SelfLiquidation: React.FC<{
 				<Svg src={WarningIcon} />
 				{notBeenFlagged ? (
 					<CratioUnderLiquidationRatioWarning
-						currentCRatioPercent={currentCratioPercent}
+						currentCRatioPercent={percentageCurrentCRatio}
 						liquidationRatioPercent={liquidationRatioPercent}
 						liquidationDelay={liquidationData.liquidationDelay}
 					/>

--- a/pages/staking/SelfLiquidation.tsx
+++ b/pages/staking/SelfLiquidation.tsx
@@ -131,7 +131,7 @@ const SelfLiquidation: React.FC<{
 	const liquidationData = liquidationQuery.data;
 
 	const canSelfLiquidate =
-		percentageCurrentCRatio.gt(0) &&
+		percentageCurrentCRatio?.gt(0) &&
 		percentageCurrentCRatio.lt(percentageTargetCRatio) &&
 		!isDelegateWallet;
 

--- a/pages/staking/SelfLiquidation.tsx
+++ b/pages/staking/SelfLiquidation.tsx
@@ -126,15 +126,21 @@ const SelfLiquidation: React.FC<{
 
 	const walletAddress = useRecoilValue(walletAddressState);
 	const delegateWallet = useRecoilValue(delegateWalletState);
-	const addressToUse = delegateWallet?.address || walletAddress!;
-
-	const liquidationQuery = useGetLiquidationDataQuery(addressToUse);
+	const isDelegateWallet = Boolean(delegateWallet?.address);
+	const liquidationQuery = useGetLiquidationDataQuery(walletAddress);
 	const liquidationData = liquidationQuery.data;
+
+	const canSelfLiquidate =
+		percentageCurrentCRatio.gt(0) &&
+		percentageCurrentCRatio.lt(percentageTargetCRatio) &&
+		!isDelegateWallet;
+
 	const snxAmountToBeLiquidatedUsdQuery = useGetSnxAmountToBeLiquidatedUsd(
 		debtBalance,
 		totalSNXBalance?.mul(SNXRate),
 		liquidationData?.selfLiquidationPenalty,
-		liquidationData?.liquidationPenalty
+		liquidationData?.liquidationPenalty,
+		canSelfLiquidate
 	);
 
 	const snxAmountToBeLiquidatedUsd = snxAmountToBeLiquidatedUsdQuery.data;

--- a/pages/staking/[[...action]].tsx
+++ b/pages/staking/[[...action]].tsx
@@ -32,7 +32,6 @@ const StakingPage = () => {
 		percentageTargetCRatio,
 		SNXRate,
 		totalEscrowBalance,
-		currentCRatio,
 		collateral,
 	} = useStakingCalculations();
 
@@ -72,7 +71,7 @@ const StakingPage = () => {
 			<LineSpacer />
 			<SelfLiquidation
 				percentageTargetCRatio={percentageTargetCRatio}
-				currentCRatio={currentCRatio}
+				percentageCurrentCRatio={percentageCurrentCRatio}
 				totalSNXBalance={collateral}
 				debtBalance={debtBalance}
 				SNXRate={SNXRate}

--- a/sections/staking/components/ActionBox.tsx
+++ b/sections/staking/components/ActionBox.tsx
@@ -11,17 +11,9 @@ import MintTab from './MintTab';
 import Burn from 'assets/svg/app/burn.svg';
 import Mint from 'assets/svg/app/mint.svg';
 import Warning from 'assets/svg/app/warning.svg';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { burnTypeState, StakingPanelType, mintTypeState } from 'store/staking';
 import SelfLiquidateTab from './SelfLiquidateTab';
-import useStakingCalculations from '../hooks/useStakingCalculations';
-import { notNill } from 'utils/ts-helpers';
-import ROUTES from 'constants/routes';
-import useSynthetixQueries from '@synthetixio/queries';
-import { delegateWalletState, walletAddressState } from 'store/wallet';
-import Wei, { wei } from '@synthetixio/wei';
-import { Synths } from 'constants/currency';
-import { getShowSelfLiquidationTab } from './helper';
 
 type ActionBoxProps = {
 	currentTab: string;
@@ -32,28 +24,8 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 	const router = useRouter();
 	const onMintTypeChange = useSetRecoilState(mintTypeState);
 	const onBurnTypeChange = useSetRecoilState(burnTypeState);
-	const walletAddress = useRecoilValue(walletAddressState);
-	const delegateWallet = useRecoilValue(delegateWalletState);
-	const { useSynthsBalancesQuery } = useSynthetixQueries();
 	const theme = useTheme();
 
-	const {
-		percentageCurrentCRatio,
-		percentageTargetCRatio,
-		isLoading,
-		debtBalance,
-		issuableSynths,
-	} = useStakingCalculations();
-	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress, { staleTime: 5000 });
-	const sUSDBalance = synthsBalancesQuery?.data?.balancesMap[Synths.sUSD]?.balance ?? wei(0);
-	const burnAmountToFixCRatio = wei(Wei.max(debtBalance.sub(issuableSynths), wei(0)));
-	const showSelfLiquidationTab = getShowSelfLiquidationTab({
-		sUSDBalance,
-		burnAmountToFixCRatio,
-		percentageCurrentCRatio,
-		percentageTargetCRatio,
-		isDelegateWallet: Boolean(delegateWallet?.address),
-	});
 	useEffect(() => {
 		if (currentTab === StakingPanelType.MINT) {
 			onBurnTypeChange(null);
@@ -62,43 +34,32 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 		}
 	}, [currentTab, onBurnTypeChange, onMintTypeChange]);
 
-	useEffect(() => {
-		if (isLoading) return;
-
-		const isOnSelLiquidateTab = router.query?.action?.[0] === StakingPanelType.SELF_LIQUIDATE;
-		if (isOnSelLiquidateTab && !showSelfLiquidationTab) {
-			// If user is on the self liquidate tab and isn't staking, navigate back staking home tab
-			router.replace(ROUTES.Staking.Home);
-		}
-	});
 	const tabData = useMemo(
-		() =>
-			[
-				{
-					title: t('staking.actions.mint.title'),
-					icon: <Svg src={Mint} />,
-					tabChildren: <MintTab />,
-					color: theme.colors.blue,
-					key: StakingPanelType.MINT,
-				},
-				{
-					title: t('staking.actions.burn.title'),
-					icon: <Svg src={Burn} />,
-					tabChildren: <BurnTab />,
-					color: theme.colors.orange,
-					key: StakingPanelType.BURN,
-				},
-				showSelfLiquidationTab
-					? {
+		() => [
+			{
+				title: t('staking.actions.mint.title'),
+				icon: <Svg src={Mint} />,
+				tabChildren: <MintTab />,
+				color: theme.colors.blue,
+				key: StakingPanelType.MINT,
+			},
+			{
+				title: t('staking.actions.burn.title'),
+				icon: <Svg src={Burn} />,
+				tabChildren: <BurnTab />,
+				color: theme.colors.orange,
+				key: StakingPanelType.BURN,
+			},
+
+			{
 				title: t('staking.actions.self-liquidate.title'),
-							icon: <Svg width={38} height={49} src={Warning} />,
-							tabChildren: <SelfLiquidateTab />,
-							color: theme.colors.pink,
-							key: StakingPanelType.SELF_LIQUIDATE,
-					  }
-					: undefined,
-			].filter(notNill),
-		[showSelfLiquidationTab, t, theme.colors.blue, theme.colors.orange, theme.colors.pink]
+				icon: <Svg width={38} height={49} src={Warning} />,
+				tabChildren: <SelfLiquidateTab />,
+				color: theme.colors.pink,
+				key: StakingPanelType.SELF_LIQUIDATE,
+			},
+		],
+		[t, theme.colors.blue, theme.colors.orange, theme.colors.pink]
 	);
 
 	return (
@@ -107,11 +68,7 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 			boxHeight={450}
 			tabData={tabData}
 			setPanelType={(key) => router.push(`/staking/${key}`)}
-			currentPanel={
-				isLoading && currentTab === StakingPanelType.SELF_LIQUIDATE
-					? StakingPanelType.MINT
-					: currentTab
-			}
+			currentPanel={currentTab}
 		/>
 	);
 };

--- a/sections/staking/components/ActionBox.tsx
+++ b/sections/staking/components/ActionBox.tsx
@@ -90,7 +90,7 @@ const ActionBox: FC<ActionBoxProps> = ({ currentTab }) => {
 				},
 				showSelfLiquidationTab
 					? {
-							title: 'Self Liquidate',
+				title: t('staking.actions.self-liquidate.title'),
 							icon: <Svg width={38} height={49} src={Warning} />,
 							tabChildren: <SelfLiquidateTab />,
 							color: theme.colors.pink,

--- a/sections/staking/components/SelfLiquidateTab/BurnMaxButton.tsx
+++ b/sections/staking/components/SelfLiquidateTab/BurnMaxButton.tsx
@@ -24,6 +24,7 @@ const BurnMaxButton: React.FC<{ amountToBurn: Wei }> = ({ amountToBurn }) => {
 	return (
 		<>
 			<StyledButton
+				data-testid="burn-max-btn"
 				variant={'primary'}
 				onClick={() => {
 					setTxModalOpen(true);

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -37,12 +37,19 @@ const SelfLiquidateTab = () => {
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
 	const sUSDBalance = synthsBalancesQuery?.data?.balancesMap[Synths.sUSD]?.balance ?? wei(0);
 	const liquidationDataQuery = useGetLiquidationDataQuery(walletAddress);
+	const delegateWallet = useRecoilValue(delegateWalletState);
 
+	const isDelegateWallet = Boolean(delegateWallet?.address);
+	const canSelfLiquidate =
+		percentageCurrentCRatio.gt(0) &&
+		percentageCurrentCRatio.lt(percentageTargetCRatio) &&
+		!isDelegateWallet;
 	const liquidationAmountsToFixCollateralQuery = useGetSnxAmountToBeLiquidatedUsd(
 		debtBalance,
 		collateral.mul(SNXRate),
 		liquidationDataQuery.data?.selfLiquidationPenalty,
-		liquidationDataQuery.data?.liquidationPenalty
+		liquidationDataQuery.data?.liquidationPenalty,
+		canSelfLiquidate
 	);
 
 	const burnAmountToFixCRatio = wei(Wei.max(debtBalance.sub(issuableSynths), wei(0)));

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -24,6 +24,7 @@ const SelfLiquidateTab = () => {
 		percentageTargetCRatio,
 		SNXRate,
 		collateral,
+		isLoading,
 	} = useStakingCalculations();
 	const { connectWallet } = Connector.useContainer();
 	const { useSynthsBalancesQuery, useGetLiquidationDataQuery } = useSynthetixQueries();
@@ -55,7 +56,7 @@ const SelfLiquidateTab = () => {
 			</ConnectWalletButtonWrapper>
 		);
 	}
-	if (!liquidationDataQuery.data || synthsBalancesQuery.isLoading) {
+	if (!liquidationDataQuery.data || synthsBalancesQuery.isLoading || isLoading) {
 		return (
 			<FlexDivJustifyCenter>
 				<Loader inline />

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -35,8 +35,8 @@ const SelfLiquidateTab = () => {
 
 	const isDelegateWallet = Boolean(delegateWallet?.address);
 	const canSelfLiquidate =
-		percentageCurrentCRatio.gt(0) &&
-		percentageCurrentCRatio.lt(percentageTargetCRatio) &&
+		percentageCurrentCRatio?.gt(0) &&
+		percentageCurrentCRatio?.lt(percentageTargetCRatio) &&
 		!isDelegateWallet;
 	const liquidationAmountsToFixCollateralQuery = useGetSnxAmountToBeLiquidatedUsd(
 		debtBalance,

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -11,6 +11,8 @@ import SelfLiquidationTabContent from './SelfLiquidationTabContent';
 import { StyledCTA } from 'sections/staking/components/common';
 import Connector from 'containers/Connector';
 import styled from 'styled-components';
+import { FlexDivJustifyCenter } from 'styles/common';
+import Loader from 'components/Loader';
 
 const SelfLiquidateTab = () => {
 	const walletAddress = useRecoilValue(walletAddressState);
@@ -53,6 +55,12 @@ const SelfLiquidateTab = () => {
 			</ConnectWalletButtonWrapper>
 		);
 	}
+	if (!liquidationDataQuery.data || synthsBalancesQuery.isLoading) {
+		return (
+			<FlexDivJustifyCenter>
+				<Loader inline />
+			</FlexDivJustifyCenter>
+		);
 	}
 
 	return (

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -8,6 +8,9 @@ import useStakingCalculations from 'sections/staking/hooks/useStakingCalculation
 import { delegateWalletState, walletAddressState } from 'store/wallet';
 import { useTranslation } from 'react-i18next';
 import SelfLiquidationTabContent from './SelfLiquidationTabContent';
+import { StyledCTA } from 'sections/staking/components/common';
+import Connector from 'containers/Connector';
+import styled from 'styled-components';
 
 const SelfLiquidateTab = () => {
 	const walletAddress = useRecoilValue(walletAddressState);
@@ -20,6 +23,7 @@ const SelfLiquidateTab = () => {
 		SNXRate,
 		collateral,
 	} = useStakingCalculations();
+	const { connectWallet } = Connector.useContainer();
 	const { useSynthsBalancesQuery, useGetLiquidationDataQuery } = useSynthetixQueries();
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
 	const sUSDBalance = synthsBalancesQuery?.data?.balancesMap[Synths.sUSD]?.balance ?? wei(0);
@@ -40,9 +44,15 @@ const SelfLiquidateTab = () => {
 	);
 
 	const burnAmountToFixCRatio = wei(Wei.max(debtBalance.sub(issuableSynths), wei(0)));
-	const liquidationAmountsData = liquidationAmountsToFixCollateralQuery.data;
-	if (!liquidationDataQuery.data || !liquidationAmountsData || synthsBalancesQuery.isLoading) {
-		return null;
+	if (!walletAddress) {
+		return (
+			<ConnectWalletButtonWrapper>
+				<StyledCTA variant="primary" size="lg" onClick={connectWallet}>
+					{t('common.wallet.connect-wallet')}
+				</StyledCTA>
+			</ConnectWalletButtonWrapper>
+		);
+	}
 	}
 
 	return (
@@ -64,4 +74,8 @@ const SelfLiquidateTab = () => {
 		</TabContainer>
 	);
 };
+const ConnectWalletButtonWrapper = styled.div`
+	width: 200px;
+	margin: 0 auto;
+`;
 export default SelfLiquidateTab;

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -1,26 +1,13 @@
 import useSynthetixQueries from '@synthetixio/queries';
-import Wei, { wei, WeiSource } from '@synthetixio/wei';
+import Wei, { wei } from '@synthetixio/wei';
 import { Synths } from 'constants/currency';
 import useGetSnxAmountToBeLiquidatedUsd from 'hooks/useGetSnxAmountToBeLiquidatedUsd';
 import { useRecoilValue } from 'recoil';
 import { TabContainer } from 'sections/staking/components/common';
 import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
-import { walletAddressState } from 'store/wallet';
-import styled from 'styled-components';
-import { formatCryptoCurrency, formatNumber, formatPercent } from 'utils/formatters/number';
-import SelfLiquidateTransactionButton from 'components/SelfLiquidateTransactionButton';
-import BurnMaxButton from './BurnMaxButton';
-import { EXTERNAL_LINKS } from 'constants/links';
-import { StyledLink } from 'sections/staking/components/common';
+import { delegateWalletState, walletAddressState } from 'store/wallet';
 import { useTranslation } from 'react-i18next';
-
-const formatSUSD = (val: WeiSource) => {
-	return formatCryptoCurrency(val, {
-		sign: '$',
-		currencyKey: Synths.sUSD,
-		minDecimals: 2,
-	});
-};
+import SelfLiquidationTabContent from './SelfLiquidationTabContent';
 
 const SelfLiquidateTab = () => {
 	const walletAddress = useRecoilValue(walletAddressState);
@@ -60,70 +47,21 @@ const SelfLiquidateTab = () => {
 
 	return (
 		<TabContainer>
-			<Container>
-				<InfoText>
-					{t('staking.self-liquidation.info.ratios', {
-						cRatio: formatPercent(percentageCurrentCRatio),
-						targetCRatio: formatPercent(percentageTargetCRatio),
-					})}
-				</InfoText>
-				<InfoText>
-					{t('staking.self-liquidation.info.burn-amount', {
-						targetCratio: formatPercent(percentageTargetCRatio),
-						burnAmountToFixCRatio: formatSUSD(burnAmountToFixCRatio),
-						balance: formatSUSD(sUSDBalance),
-					})}
-				</InfoText>
-				<Link href={EXTERNAL_LINKS.Synthetix.SIP148Liquidations}>
-					{t('staking.self-liquidation.info.liquidation-link-text')}
-				</Link>
-				{sUSDBalance.gt(0) ? (
-					<>
-						<InfoText>{t('staking.self-liquidation.info.balance-not-zero')}</InfoText>
-						<ButtonWrapper>
-							<BurnMaxButton amountToBurn={sUSDBalance} />
-						</ButtonWrapper>
-					</>
-				) : (
-					<>
-						<InfoText>
-							{t('staking.self-liquidation.info.self-liquidate-text', {
-								selfLiquidationPenalty: formatPercent(
-									liquidationDataQuery.data.selfLiquidationPenalty
-								),
-								amountToSelfLiquidate: formatCryptoCurrency(
-									liquidationAmountsData.amountToSelfLiquidateUsd.div(SNXRate),
-									{ currencyKey: 'SNX', minDecimals: 2 }
-								),
-								amountToSelfLiquidateUsd: formatNumber(
-									liquidationAmountsData.amountToSelfLiquidateUsd,
-									{ prefix: '$', minDecimals: 2 }
-								),
-							})}
-						</InfoText>
-						<ButtonWrapper>
-							<SelfLiquidateTransactionButton
-								disabled={sUSDBalance.gt(0)}
-								walletAddress={walletAddress}
-							/>
-						</ButtonWrapper>
-					</>
-				)}
-			</Container>
+			<SelfLiquidationTabContent
+				percentageCurrentCRatio={percentageCurrentCRatio}
+				percentageTargetCRatio={percentageTargetCRatio}
+				burnAmountToFixCRatio={burnAmountToFixCRatio}
+				sUSDBalance={sUSDBalance}
+				selfLiquidationPenalty={liquidationDataQuery.data.selfLiquidationPenalty}
+				liquidationPenalty={liquidationDataQuery.data.liquidationPenalty}
+				walletAddress={walletAddress}
+				isDelegateWallet={isDelegateWallet}
+				SNXRate={SNXRate}
+				amountToSelfLiquidateUsd={
+					liquidationAmountsToFixCollateralQuery.data?.amountToSelfLiquidateUsd
+				}
+			/>
 		</TabContainer>
 	);
 };
 export default SelfLiquidateTab;
-
-const Link = styled(StyledLink)`
-	font-size: 14px;
-`;
-const Container = styled.div``;
-const ButtonWrapper = styled.div`
-	display: flex;
-	justify-content: center;
-`;
-const InfoText = styled.p`
-	max-width: 640px;
-	font-size: 14px;
-`;

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.test.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.test.tsx
@@ -1,0 +1,125 @@
+import '../../../../i18n';
+
+import { render } from '@testing-library/react';
+import ContextProvider from 'test-utils/ContextProider';
+import SelfLiquidationTabContent from './SelfLiquidationTabContent';
+import { wei } from '@synthetixio/wei';
+
+describe('SelfLiquidationTabContent', () => {
+	test('delegated wallet', () => {
+		const result = render(
+			<ContextProvider>
+				{/* @ts-ignore */}
+				<SelfLiquidationTabContent isDelegateWallet={true} />
+			</ContextProvider>
+		);
+		const text = result.getByTestId('liq-delegated-wallet');
+		const link = result.getByText('Read more about liquidations');
+		expect(link).toBeInTheDocument();
+
+		expect(text).toBeInTheDocument();
+	});
+	test('C-Ratio ok', () => {
+		const result = render(
+			<ContextProvider>
+				{/* @ts-ignore */}
+				<SelfLiquidationTabContent
+					percentageCurrentCRatio={wei(3.1)}
+					percentageTargetCRatio={wei(3)}
+				/>
+			</ContextProvider>
+		);
+		const text = result.getByTestId('liq-c-ration-ok');
+		const link = result.getByText('Read more about liquidations');
+		expect(link).toBeInTheDocument();
+		expect(text).toBeInTheDocument();
+	});
+	test('Enough sUSD balance to burn', () => {
+		const result = render(
+			<ContextProvider>
+				{/* @ts-ignore */}
+				<SelfLiquidationTabContent
+					percentageCurrentCRatio={wei(2.9)}
+					percentageTargetCRatio={wei(3)}
+					burnAmountToFixCRatio={wei(100)}
+					sUSDBalance={wei(150)}
+				/>
+			</ContextProvider>
+		);
+		const text = result.getByTestId('liq-enough-susd-balance');
+		const link = result.getByText('Read more about liquidations');
+		expect(link).toBeInTheDocument();
+		expect(text).toBeInTheDocument();
+	});
+	test('Show loader when waiting for penalty data', () => {
+		const result = render(
+			<ContextProvider>
+				{/* @ts-ignore */}
+				<SelfLiquidationTabContent
+					percentageCurrentCRatio={wei(2.9)}
+					percentageTargetCRatio={wei(3)}
+					burnAmountToFixCRatio={wei(100)}
+					sUSDBalance={wei(0)}
+				/>
+			</ContextProvider>
+		);
+		const text = result.getByTestId('liq-loader');
+		expect(text).toBeInTheDocument();
+	});
+	test('sUSD balance not 0', () => {
+		const result = render(
+			<ContextProvider>
+				<SelfLiquidationTabContent
+					isDelegateWallet={false}
+					percentageCurrentCRatio={wei(2.9)}
+					percentageTargetCRatio={wei(3)}
+					burnAmountToFixCRatio={wei(100)}
+					sUSDBalance={wei(1)}
+					selfLiquidationPenalty={wei(0.2)}
+					liquidationPenalty={wei(0.3)}
+					amountToSelfLiquidateUsd={wei(120)}
+					SNXRate={wei(3)}
+					walletAddress={'123'}
+				/>
+			</ContextProvider>
+		);
+		const text = result.getByTestId('liq-ratios');
+		const text1 = result.getByTestId('liq-burn-amount');
+		const text2 = result.getByTestId('liq-balance-not-zero');
+		const button = result.getByTestId('burn-max-btn');
+		const link = result.getByText('Read more about liquidations');
+		expect(link).toBeInTheDocument();
+		expect(text).toBeInTheDocument();
+		expect(text1).toBeInTheDocument();
+		expect(text2).toBeInTheDocument();
+		expect(button).toBeInTheDocument();
+	});
+	test('sUSD balance is 0', () => {
+		const result = render(
+			<ContextProvider>
+				<SelfLiquidationTabContent
+					isDelegateWallet={false}
+					percentageCurrentCRatio={wei(2.9)}
+					percentageTargetCRatio={wei(3)}
+					burnAmountToFixCRatio={wei(100)}
+					sUSDBalance={wei(0)}
+					selfLiquidationPenalty={wei(0.2)}
+					liquidationPenalty={wei(0.3)}
+					amountToSelfLiquidateUsd={wei(120)}
+					SNXRate={wei(3)}
+					walletAddress={'123'}
+				/>
+			</ContextProvider>
+		);
+		const text = result.getByTestId('liq-ratios');
+		const text1 = result.getByTestId('liq-burn-amount');
+		const text2 = result.getByTestId('self-liquidate-info');
+		const button = result.getByTestId('self-liquidate-btn');
+		const link = result.getByText('Read more about liquidations');
+		expect(link).toBeInTheDocument();
+		expect(text).toBeInTheDocument();
+		expect(text1).toBeInTheDocument();
+		expect(text2).toBeInTheDocument();
+		expect(button).toBeInTheDocument();
+	});
+});

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.test.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.test.tsx
@@ -51,6 +51,21 @@ describe('SelfLiquidationTabContent', () => {
 		expect(link).toBeInTheDocument();
 		expect(text).toBeInTheDocument();
 	});
+	test('Not staking', () => {
+		const result = render(
+			<ContextProvider>
+				{/* @ts-ignore */}
+				<SelfLiquidationTabContent
+					percentageCurrentCRatio={wei(0)}
+					percentageTargetCRatio={wei(3)}
+					burnAmountToFixCRatio={wei(0)}
+					sUSDBalance={wei(0)}
+				/>
+			</ContextProvider>
+		);
+		const text = result.getByTestId('not-staking');
+		expect(text).toBeInTheDocument();
+	});
 	test('Show loader when waiting for penalty data', () => {
 		const result = render(
 			<ContextProvider>

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
@@ -1,0 +1,160 @@
+import SelfLiquidateTransactionButton from 'components/SelfLiquidateTransactionButton';
+import BurnMaxButton from './BurnMaxButton';
+import { EXTERNAL_LINKS } from 'constants/links';
+import { StyledLink } from 'sections/staking/components/common';
+import { formatCryptoCurrency, formatNumber, formatPercent } from 'utils/formatters/number';
+import Wei, { WeiSource } from '@synthetixio/wei';
+import { useTranslation } from 'react-i18next';
+import { Synths } from 'constants/currency';
+import styled from 'styled-components';
+import Loader from 'components/Loader';
+import { FlexDivJustifyCenter } from 'styles/common';
+
+const formatSUSD = (val: WeiSource) =>
+	formatCryptoCurrency(val, {
+		sign: '$',
+		currencyKey: Synths.sUSD,
+		minDecimals: 2,
+	});
+
+const SelfLiquidationTabContent: React.FC<{
+	percentageCurrentCRatio: Wei;
+	percentageTargetCRatio: Wei;
+	burnAmountToFixCRatio: Wei;
+	sUSDBalance: Wei;
+	selfLiquidationPenalty?: Wei;
+	liquidationPenalty?: Wei;
+	walletAddress: string;
+	isDelegateWallet: boolean;
+	SNXRate: Wei;
+	amountToSelfLiquidateUsd?: Wei;
+}> = ({
+	isDelegateWallet,
+	percentageCurrentCRatio,
+	percentageTargetCRatio,
+	burnAmountToFixCRatio,
+	selfLiquidationPenalty,
+	liquidationPenalty,
+	walletAddress,
+	sUSDBalance,
+	SNXRate,
+	amountToSelfLiquidateUsd,
+}) => {
+	const { t } = useTranslation();
+
+	if (isDelegateWallet) {
+		return (
+			<Container>
+				<InfoText>{t('staking.self-liquidation.info.delegate-wallet')}</InfoText>
+				<Link href={EXTERNAL_LINKS.Synthetix.SIP148Liquidations}>
+					{t('staking.self-liquidation.info.liquidation-link-text')}
+				</Link>
+			</Container>
+		);
+	}
+	if (percentageCurrentCRatio.gt(percentageTargetCRatio)) {
+		return (
+			<Container>
+				<InfoText>
+					{t('staking.self-liquidation.info.c-ratio-ok', {
+						cRatio: formatPercent(percentageCurrentCRatio),
+						targetCRatio: formatPercent(percentageTargetCRatio),
+					})}
+				</InfoText>
+				<Link href={EXTERNAL_LINKS.Synthetix.SIP148Liquidations}>
+					{t('staking.self-liquidation.info.liquidation-link-text')}
+				</Link>
+			</Container>
+		);
+	}
+
+	if (sUSDBalance.lt(burnAmountToFixCRatio)) {
+		return (
+			<Container>
+				<InfoText>
+					{t('staking.self-liquidation.info.enough-susd-balance', {
+						targetCRatio: formatPercent(percentageTargetCRatio),
+						burnAmountToFixCRatio: formatSUSD(burnAmountToFixCRatio),
+						balance: formatSUSD(sUSDBalance),
+					})}
+				</InfoText>
+				<Link href={EXTERNAL_LINKS.Synthetix.SIP148Liquidations}>
+					{t('staking.self-liquidation.info.liquidation-link-text')}
+				</Link>
+			</Container>
+		);
+	}
+
+	if (!selfLiquidationPenalty || !liquidationPenalty || !amountToSelfLiquidateUsd)
+		return (
+			<FlexDivJustifyCenter>
+				<Loader inline />
+			</FlexDivJustifyCenter>
+		);
+	return (
+		<Container>
+			<InfoText>
+				{t('staking.self-liquidation.info.ratios', {
+					cRatio: formatPercent(percentageCurrentCRatio),
+					targetCRatio: formatPercent(percentageTargetCRatio),
+				})}
+			</InfoText>
+			<InfoText>
+				{t('staking.self-liquidation.info.burn-amount', {
+					targetCratio: formatPercent(percentageTargetCRatio),
+					burnAmountToFixCRatio: formatSUSD(burnAmountToFixCRatio),
+					balance: formatSUSD(sUSDBalance),
+				})}
+			</InfoText>
+			<Link href={EXTERNAL_LINKS.Synthetix.SIP148Liquidations}>
+				{t('staking.self-liquidation.info.liquidation-link-text')}
+			</Link>
+			{sUSDBalance.gt(0) ? (
+				<>
+					<InfoText>{t('staking.self-liquidation.info.balance-not-zero')}</InfoText>
+					<ButtonWrapper>
+						<BurnMaxButton amountToBurn={sUSDBalance} />
+					</ButtonWrapper>
+				</>
+			) : (
+				<>
+					<InfoText>
+						{t('staking.self-liquidation.info.self-liquidate-text', {
+							selfLiquidationPenalty: formatPercent(selfLiquidationPenalty),
+							amountToSelfLiquidate: formatCryptoCurrency(amountToSelfLiquidateUsd.div(SNXRate), {
+								currencyKey: 'SNX',
+								minDecimals: 2,
+							}),
+							amountToSelfLiquidateUsd: formatNumber(amountToSelfLiquidateUsd, {
+								prefix: '$',
+								minDecimals: 2,
+							}),
+						})}
+					</InfoText>
+					<ButtonWrapper>
+						<SelfLiquidateTransactionButton
+							disabled={sUSDBalance.gt(0)}
+							walletAddress={walletAddress}
+						/>
+					</ButtonWrapper>
+				</>
+			)}
+		</Container>
+	);
+};
+
+const Link = styled(StyledLink)`
+	font-size: 14px;
+`;
+const Container = styled.div`
+	width: 100%;
+`;
+const ButtonWrapper = styled.div`
+	display: flex;
+	justify-content: center;
+`;
+const InfoText = styled.p`
+	max-width: 640px;
+	font-size: 14px;
+`;
+export default SelfLiquidationTabContent;

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
@@ -45,7 +45,9 @@ const SelfLiquidationTabContent: React.FC<{
 	if (isDelegateWallet) {
 		return (
 			<Container>
-				<InfoText>{t('staking.self-liquidation.info.delegate-wallet')}</InfoText>
+				<InfoText data-testid="liq-delegated-wallet">
+					{t('staking.self-liquidation.info.delegate-wallet')}
+				</InfoText>
 				<Link href={EXTERNAL_LINKS.Synthetix.SIP148Liquidations}>
 					{t('staking.self-liquidation.info.liquidation-link-text')}
 				</Link>
@@ -55,7 +57,7 @@ const SelfLiquidationTabContent: React.FC<{
 	if (percentageCurrentCRatio.gt(percentageTargetCRatio)) {
 		return (
 			<Container>
-				<InfoText>
+				<InfoText data-testid="liq-c-ration-ok">
 					{t('staking.self-liquidation.info.c-ratio-ok', {
 						cRatio: formatPercent(percentageCurrentCRatio),
 						targetCRatio: formatPercent(percentageTargetCRatio),
@@ -68,10 +70,10 @@ const SelfLiquidationTabContent: React.FC<{
 		);
 	}
 
-	if (sUSDBalance.lt(burnAmountToFixCRatio)) {
+	if (sUSDBalance.gt(burnAmountToFixCRatio)) {
 		return (
 			<Container>
-				<InfoText>
+				<InfoText data-testid="liq-enough-susd-balance">
 					{t('staking.self-liquidation.info.enough-susd-balance', {
 						targetCRatio: formatPercent(percentageTargetCRatio),
 						burnAmountToFixCRatio: formatSUSD(burnAmountToFixCRatio),
@@ -87,19 +89,19 @@ const SelfLiquidationTabContent: React.FC<{
 
 	if (!selfLiquidationPenalty || !liquidationPenalty || !amountToSelfLiquidateUsd)
 		return (
-			<FlexDivJustifyCenter>
+			<FlexDivJustifyCenter data-testid="liq-loader">
 				<Loader inline />
 			</FlexDivJustifyCenter>
 		);
 	return (
 		<Container>
-			<InfoText>
+			<InfoText data-testid="liq-ratios">
 				{t('staking.self-liquidation.info.ratios', {
 					cRatio: formatPercent(percentageCurrentCRatio),
 					targetCRatio: formatPercent(percentageTargetCRatio),
 				})}
 			</InfoText>
-			<InfoText>
+			<InfoText data-testid="liq-burn-amount">
 				{t('staking.self-liquidation.info.burn-amount', {
 					targetCratio: formatPercent(percentageTargetCRatio),
 					burnAmountToFixCRatio: formatSUSD(burnAmountToFixCRatio),
@@ -111,14 +113,16 @@ const SelfLiquidationTabContent: React.FC<{
 			</Link>
 			{sUSDBalance.gt(0) ? (
 				<>
-					<InfoText>{t('staking.self-liquidation.info.balance-not-zero')}</InfoText>
+					<InfoText data-testid="liq-balance-not-zero">
+						{t('staking.self-liquidation.info.balance-not-zero')}
+					</InfoText>
 					<ButtonWrapper>
 						<BurnMaxButton amountToBurn={sUSDBalance} />
 					</ButtonWrapper>
 				</>
 			) : (
 				<>
-					<InfoText>
+					<InfoText data-testid="self-liquidate-info">
 						{t('staking.self-liquidation.info.self-liquidate-text', {
 							selfLiquidationPenalty: formatPercent(selfLiquidationPenalty),
 							amountToSelfLiquidate: formatCryptoCurrency(amountToSelfLiquidateUsd.div(SNXRate), {

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
@@ -54,6 +54,15 @@ const SelfLiquidationTabContent: React.FC<{
 			</Container>
 		);
 	}
+	if (percentageCurrentCRatio.eq(0)) {
+		return (
+			<Container>
+				<InfoText data-testid="not-staking">
+					{t('staking.self-liquidation.info.not-staking')}
+				</InfoText>
+			</Container>
+		);
+	}
 	if (percentageCurrentCRatio.gt(percentageTargetCRatio)) {
 		return (
 			<Container>

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
@@ -54,7 +54,7 @@ const SelfLiquidationTabContent: React.FC<{
 			</Container>
 		);
 	}
-	if (percentageCurrentCRatio.eq(0)) {
+	if (!percentageCurrentCRatio || percentageCurrentCRatio.eq(0)) {
 		return (
 			<Container>
 				<InfoText data-testid="not-staking">

--- a/sections/staking/components/helper.test.ts
+++ b/sections/staking/components/helper.test.ts
@@ -1,7 +1,6 @@
 import { wei } from '@synthetixio/wei';
 import {
 	getMintAmount,
-	getShowSelfLiquidationTab,
 	getStakingAmount,
 	getTransferableAmountFromBurn,
 	getTransferableAmountFromMint,
@@ -42,55 +41,5 @@ describe('staking helpers', () => {
 			transferable
 		);
 		expect(result.toString(0)).toBe('70');
-	});
-	test('getShowSelfLiquidationTab should show', () => {
-		const result = getShowSelfLiquidationTab({
-			sUSDBalance: wei(10),
-			burnAmountToFixCRatio: wei(20), // more than balance
-			percentageCurrentCRatio: wei(2.9), // less than target
-			percentageTargetCRatio: wei(3),
-			isDelegateWallet: false,
-		});
-		expect(result).toBe(true);
-	});
-	test('getShowSelfLiquidationTab delegate wallet', () => {
-		const result = getShowSelfLiquidationTab({
-			sUSDBalance: wei(10),
-			burnAmountToFixCRatio: wei(20), // more than balance
-			percentageCurrentCRatio: wei(2.9), // less than target
-			percentageTargetCRatio: wei(3),
-			isDelegateWallet: true,
-		});
-		expect(result).toBe(false);
-	});
-	test('getShowSelfLiquidationTab sUSD balance bigger than burnAmountToFixCRatio ', () => {
-		const result = getShowSelfLiquidationTab({
-			sUSDBalance: wei(30),
-			burnAmountToFixCRatio: wei(20), // less than balance so should show
-			percentageCurrentCRatio: wei(2.9),
-			percentageTargetCRatio: wei(3),
-			isDelegateWallet: false,
-		});
-		expect(result).toBe(false);
-	});
-	test('getShowSelfLiquidationTab percentageCurrentCRatio is 0', () => {
-		const result = getShowSelfLiquidationTab({
-			sUSDBalance: wei(10),
-			burnAmountToFixCRatio: wei(20),
-			percentageCurrentCRatio: wei(0),
-			percentageTargetCRatio: wei(3),
-			isDelegateWallet: false,
-		});
-		expect(result).toBe(false);
-	});
-	test('getShowSelfLiquidationTab percentageCurrentCRatio higher than percentageTargetCRatio', () => {
-		const result = getShowSelfLiquidationTab({
-			sUSDBalance: wei(10),
-			burnAmountToFixCRatio: wei(20),
-			percentageCurrentCRatio: wei(3.1),
-			percentageTargetCRatio: wei(3),
-			isDelegateWallet: false,
-		});
-		expect(result).toBe(false);
 	});
 });

--- a/sections/staking/components/helper.ts
+++ b/sections/staking/components/helper.ts
@@ -35,24 +35,3 @@ export function sanitiseValue(value: Wei) {
 		return value;
 	}
 }
-
-export function getShowSelfLiquidationTab({
-	percentageCurrentCRatio,
-	percentageTargetCRatio,
-	burnAmountToFixCRatio,
-	sUSDBalance,
-	isDelegateWallet,
-}: {
-	percentageCurrentCRatio: Wei;
-	percentageTargetCRatio: Wei;
-	burnAmountToFixCRatio: Wei;
-	sUSDBalance: Wei;
-	isDelegateWallet: boolean;
-}) {
-	return (
-		percentageCurrentCRatio.gt(0) &&
-		percentageCurrentCRatio.lt(percentageTargetCRatio) &&
-		sUSDBalance.lt(burnAmountToFixCRatio) &&
-		!isDelegateWallet
-	);
-}

--- a/test-utils/ContextProider.tsx
+++ b/test-utils/ContextProider.tsx
@@ -1,9 +1,17 @@
+import { createQueryContext, SynthetixQueryContextProvider } from '@synthetixio/queries';
 import { FC } from 'react';
 import { ThemeProvider } from 'styled-components';
 import theme from 'styles/theme';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 const ContextProvider: FC = ({ children }) => {
-	return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+	return (
+		<QueryClientProvider client={new QueryClient()} contextSharing={true}>
+			<SynthetixQueryContextProvider value={createQueryContext({ networkId: 10 })}>
+				<ThemeProvider theme={theme}>{children}</ThemeProvider>
+			</SynthetixQueryContextProvider>
+		</QueryClientProvider>
+	);
 };
 
 export default ContextProvider;

--- a/translations/en.json
+++ b/translations/en.json
@@ -390,6 +390,7 @@
 				"burn-amount": "To get your C-Ratio back to the target of {{targetCRatio}} you need to burn {{burnAmountToFixCRatio}}. Your current balance is {{balance}}.",
 				"liquidation-link-text": "Read more about liquidations",
 				"c-ratio-ok": "Your C-Ratio of {{cRatio}} is above the target C-Ratio of {{targetCRatio}} which means you can't and dont have to self liquidate.",
+				"not-staking": "Currently you are not staking, so there's no debt to self liquidate. Head over to the Mint tab to start earning.",
 				"enough-susd-balance": "To get your C-Ratio back to target C-Ratio of {{targetCRatio}} you need to burn {{burnAmountToFixCRatio}}. Your balance is {{balance}} so there's no need to self liquidate.",
 				"delegate-wallet": "As a delegated wallet you can't self liquidate.",
 				"balance-not-zero": "Since your balance is not zero you should burn all your sUSD before self liquidating",

--- a/translations/en.json
+++ b/translations/en.json
@@ -384,10 +384,14 @@
 			"self-liquidating": "Self Liquidating"
 		},
 		"self-liquidation": {
+			"title": "Self Liquidate",
 			"info": {
 				"ratios": "Your C-Ratio {{cRatio}} is below the target C-Ratio of {{targetCRatio}}.",
 				"burn-amount": "To get your C-Ratio back to the target of {{targetCRatio}} you need to burn {{burnAmountToFixCRatio}}. Your current balance is {{balance}}.",
 				"liquidation-link-text": "Read more about liquidations",
+				"c-ratio-ok": "Your C-Ratio of {{cRatio}} is above the target C-Ratio of {{targetCRatio}} which means you can't and dont have to self liquidate.",
+				"enough-susd-balance": "To get your C-Ratio back to target C-Ratio of {{targetCRatio}} you need to burn {{burnAmountToFixCRatio}}. Your balance is {{balance}} so there's no need to self liquidate.",
+				"delegate-wallet": "As a delegated wallet you can't self liquidate.",
 				"balance-not-zero": "Since your balance is not zero you should burn all your sUSD before self liquidating",
 				"self-liquidate-text": "You can also opt to self liquidate and incur a {{selfLiquidationPenalty}} penalty on your staked SNX needed to bring you to the 300% target. This would cause you to incur a penalty of {{amountToSelfLiquidate}} ({{amountToSelfLiquidateUsd}})."
 			}

--- a/translations/en.json
+++ b/translations/en.json
@@ -347,7 +347,8 @@
 					"unstaking": "Unstaking",
 					"burning": "Burning"
 				}
-			}
+			},
+			"self-liquidate": { "title": "Self Liquidate" }
 		},
 		"info": {
 			"mint": {


### PR DESCRIPTION
Instead of hiding the self liquidation tab we now have it always rendering with some text explanations for why you cant self liquidate:
sUSD balance bigger than burnAmountToTargetRation
![Screen Shot 2022-05-31 at 1 31 10 pm](https://user-images.githubusercontent.com/5688912/171087399-1891b5e1-4142-40c9-8a2b-519f9629244a.png)
Healthy C-Ratio:
![Screen Shot 2022-05-31 at 1 29 41 pm](https://user-images.githubusercontent.com/5688912/171087426-6e055a65-60c8-453c-b023-600763add7e9.png)
Loader:
![Screen Shot 2022-05-31 at 1 27 52 pm](https://user-images.githubusercontent.com/5688912/171087445-9337646e-f52a-498e-89a2-5510cad4b6e2.png)
Delegated wallet:
![Screen Shot 2022-05-31 at 1 26 09 pm](https://user-images.githubusercontent.com/5688912/171087461-0d2afe6a-3fd9-4023-ad03-fd785ea45c9d.png)
Wallet not connected:
![Screen Shot 2022-05-31 at 1 24 08 pm](https://user-images.githubusercontent.com/5688912/171087483-8cc50c8d-3cee-4d46-89a8-4727949cd83e.png)
Wallet not staking:
![Screen Shot 2022-05-31 at 1 23 57 pm](https://user-images.githubusercontent.com/5688912/171087515-1b9e1c69-0c19-4d12-b870-f2560203a615.png)

