### PR TITLE
Self liquidation side panel

### DIFF
--- a/sections/staking/components/InfoBox.tsx
+++ b/sections/staking/components/InfoBox.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { StakingPanelType, BurnActionType, burnTypeState } from 'store/staking';
-import { MintInfo, BurnInfo, ClearDebtInfo } from './StakingInfo';
+import { MintInfo, BurnInfo, ClearDebtInfo, SelfLiquidationInfo } from './StakingInfo';
 
 type InfoBoxProps = {
 	currentTab: string;
@@ -11,12 +11,14 @@ type InfoBoxProps = {
 const InfoBox: React.FC<InfoBoxProps> = ({ currentTab }) => {
 	const burnType = useRecoilValue(burnTypeState);
 	const isMint = currentTab === StakingPanelType.MINT;
+	const isSelfLiquidation = currentTab === StakingPanelType.SELF_LIQUIDATE;
 	const isClearDebt = burnType === BurnActionType.CLEAR;
 
-	return useMemo(
-		() => (isMint ? <MintInfo /> : isClearDebt ? <ClearDebtInfo /> : <BurnInfo />),
-		[isMint, isClearDebt]
-	);
+	return useMemo(() => {
+		if (isMint) return <MintInfo />;
+		if (isSelfLiquidation) return <SelfLiquidationInfo />;
+		return isClearDebt ? <ClearDebtInfo /> : <BurnInfo />;
+	}, [isMint, isSelfLiquidation, isClearDebt]);
 };
 
 export default InfoBox;

--- a/sections/staking/components/StakingInfo/InfoLayout.tsx
+++ b/sections/staking/components/StakingInfo/InfoLayout.tsx
@@ -77,6 +77,8 @@ const InfoLayout: FC<InfoLayoutProps> = ({
 				return t('staking.info.burn.title');
 			case StakingPanelType.CLEAR:
 				return t('staking.info.clear.title');
+			case StakingPanelType.SELF_LIQUIDATE:
+				return t('staking.info.self-liquidate.title');
 		}
 	}, [infoType, t]);
 
@@ -88,6 +90,8 @@ const InfoLayout: FC<InfoLayoutProps> = ({
 				return 'staking.info.burn.subtitle';
 			case StakingPanelType.CLEAR:
 				return 'staking.info.clear.subtitle';
+			case StakingPanelType.SELF_LIQUIDATE:
+				return 'staking.info.self-liquidate.subtitle';
 		}
 	}, [infoType]);
 

--- a/sections/staking/components/StakingInfo/SelfLiquidationInfo.tsx
+++ b/sections/staking/components/StakingInfo/SelfLiquidationInfo.tsx
@@ -1,0 +1,114 @@
+import useSynthetixQueries from '@synthetixio/queries';
+import { wei } from '@synthetixio/wei';
+import { CryptoCurrency, Synths } from 'constants/currency';
+import useGetSnxAmountToBeLiquidatedUsd from 'hooks/useGetSnxAmountToBeLiquidatedUsd';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRecoilValue } from 'recoil';
+import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
+import { StakingPanelType } from 'store/staking';
+import { walletAddressState } from 'store/wallet';
+import { sanitiseValue } from '../helper';
+import InfoLayout from './InfoLayout';
+import { getButtonDisplaying, getSelfLiquidationChanges } from './selfLiquidationInfoCalculations';
+
+const SelfLiquidationInfo = () => {
+	const {
+		collateral,
+		percentageTargetCRatio,
+		percentageCurrentCRatio,
+		stakedCollateral,
+		debtBalance,
+		SNXRate,
+		balance: nonEscrowedBalance,
+	} = useStakingCalculations();
+	const walletAddress = useRecoilValue(walletAddressState);
+	const { useSynthsBalancesQuery, useGetLiquidationDataQuery } = useSynthetixQueries();
+
+	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
+
+	const sUSDBalance = synthsBalancesQuery?.data?.balancesMap[Synths.sUSD]?.balance ?? wei(0);
+	const buttonDisplaying = getButtonDisplaying({
+		sUSDBalance,
+		debtBalance,
+		percentageCurrentCRatio,
+		percentageTargetCRatio,
+	});
+	const liqData = useGetLiquidationDataQuery(walletAddress, {
+		enabled: buttonDisplaying === 'SELF_LIQUIDATION_BUTTON',
+	});
+	const selfLiquidationPenalty = liqData.data?.selfLiquidationPenalty || wei(0);
+
+	const liquidationAmount = useGetSnxAmountToBeLiquidatedUsd(
+		debtBalance,
+		SNXRate.gt(0) ? collateral.div(SNXRate) : undefined,
+		selfLiquidationPenalty,
+		liqData.data?.liquidationPenalty,
+		buttonDisplaying === 'SELF_LIQUIDATION_BUTTON'
+	);
+	const usdToBeLiquidatedWithPenalty = liquidationAmount.data?.amountToSelfLiquidateUsd || wei(0);
+	const { changedCRatio, changedCollateral, changedDebt } = getSelfLiquidationChanges({
+		collateral,
+		stakedCollateral,
+		debtBalance,
+		SNXRate,
+		nonEscrowedBalance,
+		sUSDBalance,
+		selfLiquidationPenalty,
+		usdToBeLiquidatedWithPenalty,
+		buttonDisplaying,
+	});
+	const { t } = useTranslation();
+	const stakingInfo = useMemo(() => {
+		return {
+			barRows: [],
+			dataRows: [
+				{
+					title: t('staking.info.table.staked'),
+					value: sanitiseValue(stakedCollateral),
+					changedValue: changedCollateral,
+
+					currencyKey: CryptoCurrency.SNX,
+				},
+				{
+					title: t('staking.info.table.c-ratio'),
+					value: percentageCurrentCRatio.eq(0)
+						? wei(0)
+						: sanitiseValue(percentageCurrentCRatio.mul(100)),
+					changedValue: sanitiseValue(changedCRatio.mul(100)),
+					currencyKey: '%',
+				},
+				{
+					title: t('staking.info.table.susd-balance'),
+					value: sanitiseValue(sUSDBalance),
+					changedValue: wei(0),
+				},
+				{
+					title: t('staking.info.table.debt'),
+					value: sanitiseValue(debtBalance),
+					changedValue: changedDebt,
+					currencyKey: Synths.sUSD,
+				},
+			],
+		};
+	}, [
+		changedCRatio,
+		changedCollateral,
+		changedDebt,
+		debtBalance,
+		percentageCurrentCRatio,
+		sUSDBalance,
+		stakedCollateral,
+		t,
+	]);
+	return (
+		<InfoLayout
+			targetCratioPercent={percentageTargetCRatio}
+			stakingInfo={stakingInfo}
+			isInputEmpty={buttonDisplaying === undefined}
+			collateral={collateral}
+			infoType={StakingPanelType.SELF_LIQUIDATE}
+		/>
+	);
+};
+export default SelfLiquidationInfo;

--- a/sections/staking/components/StakingInfo/index.ts
+++ b/sections/staking/components/StakingInfo/index.ts
@@ -1,5 +1,6 @@
 import MintInfo from './MintInfo';
 import BurnInfo from './BurnInfo';
 import ClearDebtInfo from './ClearDebtInfo';
+import SelfLiquidationInfo from './SelfLiquidationInfo';
 
-export { MintInfo, BurnInfo, ClearDebtInfo };
+export { MintInfo, BurnInfo, ClearDebtInfo, SelfLiquidationInfo };

--- a/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.test.ts
+++ b/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.test.ts
@@ -1,0 +1,116 @@
+import { wei } from '@synthetixio/wei';
+import { getButtonDisplaying, getSelfLiquidationChanges } from './selfLiquidationInfoCalculations';
+
+describe('selfLiquidationCalculations', () => {
+	describe('getButtonDisplaying', () => {
+		test('burn max button', () => {
+			const result = getButtonDisplaying({
+				percentageCurrentCRatio: wei(2),
+				percentageTargetCRatio: wei(3),
+				sUSDBalance: wei(100),
+				debtBalance: wei(150),
+			});
+			expect(result).toBe('BURN_MAX_BUTTON');
+		});
+		test('self liquidation button', () => {
+			const result = getButtonDisplaying({
+				percentageCurrentCRatio: wei(2),
+				percentageTargetCRatio: wei(3),
+				sUSDBalance: wei(0),
+				debtBalance: wei(150),
+			});
+			expect(result).toBe('SELF_LIQUIDATION_BUTTON');
+		});
+		test('not displaying due to C-Ratio ok', () => {
+			const result = getButtonDisplaying({
+				percentageCurrentCRatio: wei(3.1),
+				percentageTargetCRatio: wei(3),
+				sUSDBalance: wei(0),
+				debtBalance: wei(150),
+			});
+			expect(result).toBe(undefined);
+		});
+		test('not displaying due to not staking', () => {
+			const result = getButtonDisplaying({
+				percentageCurrentCRatio: wei(0),
+				percentageTargetCRatio: wei(3),
+				sUSDBalance: wei(0),
+				debtBalance: wei(150),
+			});
+			expect(result).toBe(undefined);
+		});
+		test('not displaying due to not sUSD balance bigger than debt balance', () => {
+			const result = getButtonDisplaying({
+				percentageCurrentCRatio: wei(2.9),
+				percentageTargetCRatio: wei(3),
+				sUSDBalance: wei(151),
+				debtBalance: wei(150),
+			});
+			expect(result).toBe(undefined);
+		});
+	});
+
+	describe('getSelfLiquidationChanges', () => {
+		test('BURN_MAX_BUTTON displaying', () => {
+			const result = getSelfLiquidationChanges({
+				collateral: wei(50),
+				stakedCollateral: wei(50),
+				debtBalance: wei(100),
+				SNXRate: wei(3),
+				nonEscrowedBalance: wei(50),
+				sUSDBalance: wei(50),
+				selfLiquidationPenalty: wei(0.2),
+				usdToBeLiquidatedWithPenalty: wei(10),
+				buttonDisplaying: 'BURN_MAX_BUTTON',
+			});
+			expect(result.changedCollateral.toString(2)).toBe('50.00'); // no change
+			expect(result.changedDebt.toString(2)).toBe('50.00'); // debtBalance - sUSDBalance = 100 -50
+			expect(result.changedCRatio.toString(2)).toBe('3.00'); // collateral / (debtBalance / snxPrice) = 150/ 50
+		});
+		test('SELF_LIQUIDATION_BUTTON displaying, low non escrowed balance', () => {
+			const result = getSelfLiquidationChanges({
+				collateral: wei(50),
+				stakedCollateral: wei(50),
+				debtBalance: wei(100),
+				SNXRate: wei(3),
+				nonEscrowedBalance: wei(1),
+				sUSDBalance: wei(0),
+				selfLiquidationPenalty: wei(0.2),
+				usdToBeLiquidatedWithPenalty: wei(10),
+				buttonDisplaying: 'SELF_LIQUIDATION_BUTTON',
+			});
+			expect(result.changedCollateral.toString(2)).toBe('49.00'); // collateral - nonEscrowedBalance
+			/**
+			 * debtToBeRemovedToGetBackToTarget = (usdToBeLiquidatedWithPenalty)/ (1 + selfLiquidationPenalty) = 10 / 1.2 = 8.33
+			 * debtToBeRemoved = debtToBeRemovedToGetBackToTarget * nonEscrowedBalance / (usdToBeLiquidatedWithPenalty/ SNXRate) = 8.33 * 1 / (10 / 3)  = 2.499
+			 * debtBalance - debtToBeRemoved = 100 - 2.499 =97.50
+			 */
+			expect(result.changedDebt.toString(2)).toBe('97.50');
+			expect(result.changedCRatio.toString(2)).toBe('1.51'); // changedCollateral / (changedDebt/3 ) = 49 / ( 97.5 / 3 )  = 1.50769231
+		});
+		test('SELF_LIQUIDATION_BUTTON displaying, high non escrowed balance', () => {
+			const result = getSelfLiquidationChanges({
+				collateral: wei(50),
+				stakedCollateral: wei(50),
+				debtBalance: wei(100),
+				SNXRate: wei(3),
+				nonEscrowedBalance: wei(50),
+				sUSDBalance: wei(0),
+				selfLiquidationPenalty: wei(0.2),
+				usdToBeLiquidatedWithPenalty: wei(10),
+				buttonDisplaying: 'SELF_LIQUIDATION_BUTTON',
+			});
+			expect(result.changedCollateral.toString(2)).toBe('46.67'); // collateral - (usdToBeLiquidatedWithPenalty/ snxRate ) = 50 - (10/3) = 46.67
+			/**
+			 * debtToBeRemovedToGetBackToTarget = (usdToBeLiquidatedWithPenalty)/ (1 + selfLiquidationPenalty) = 10 / 1.2 = 8.33
+			 * debtBalance - debtToBeRemovedToGetBackToTarget = 100 - 8.33 = 91.67
+			 */
+			expect(result.changedDebt.toString(2)).toBe('91.67');
+			/**
+			 * Note: with real data we would expect this to get us back to the target c-ratio. The reason it's look low here is due to the arbitrary usdToBeLiquidatedWithPenalty passed in
+			 * changedCollateral / (changedDebt/3 ) = 46.67 / ( 91.67 / 3 )  = 1.53
+			 */
+			expect(result.changedCRatio.toString(2)).toBe('1.53');
+		});
+	});
+});

--- a/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.ts
+++ b/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.ts
@@ -1,0 +1,87 @@
+import Wei, { wei } from '@synthetixio/wei';
+
+export const getButtonDisplaying = ({
+	percentageTargetCRatio,
+	percentageCurrentCRatio,
+	sUSDBalance,
+	debtBalance,
+}: {
+	percentageTargetCRatio: Wei;
+	percentageCurrentCRatio: Wei;
+	sUSDBalance: Wei;
+	debtBalance: Wei;
+}) => {
+	const notStaking = percentageCurrentCRatio.eq(0);
+	if (notStaking) return undefined;
+	const cRatioOk = percentageCurrentCRatio.gt(percentageTargetCRatio);
+	if (cRatioOk) return undefined;
+	const selfLiquidateButtonDisplaying = sUSDBalance.eq(0);
+
+	if (selfLiquidateButtonDisplaying) return 'SELF_LIQUIDATION_BUTTON';
+	const burnMaxButtonIsDisplaying = sUSDBalance.gt(0) && sUSDBalance.lt(debtBalance);
+	if (burnMaxButtonIsDisplaying) return 'BURN_MAX_BUTTON';
+	return undefined;
+};
+
+export const getSelfLiquidationChanges = ({
+	collateral,
+	stakedCollateral,
+	debtBalance,
+	SNXRate,
+	nonEscrowedBalance,
+	sUSDBalance,
+	selfLiquidationPenalty,
+	usdToBeLiquidatedWithPenalty,
+	buttonDisplaying,
+}: {
+	collateral: Wei;
+	stakedCollateral: Wei;
+	debtBalance: Wei;
+	SNXRate: Wei;
+	nonEscrowedBalance: Wei;
+	sUSDBalance: Wei;
+	selfLiquidationPenalty: Wei;
+	usdToBeLiquidatedWithPenalty: Wei;
+	buttonDisplaying: ReturnType<typeof getButtonDisplaying>;
+}) => {
+	const snxToBeLiquidatedToGetBackToTarget = usdToBeLiquidatedWithPenalty.gt(0)
+		? usdToBeLiquidatedWithPenalty.div(SNXRate)
+		: wei(0);
+
+	const getChangedDebt = () => {
+		if (buttonDisplaying === 'BURN_MAX_BUTTON') {
+			return debtBalance.sub(sUSDBalance);
+		}
+		if (buttonDisplaying === 'SELF_LIQUIDATION_BUTTON') {
+			const debtToBeRemovedToGetBackToTarget = usdToBeLiquidatedWithPenalty.div(
+				wei(1).add(selfLiquidationPenalty) // removing the penalty
+			);
+
+			const debtToBeRemoved = snxToBeLiquidatedToGetBackToTarget.gt(nonEscrowedBalance)
+				? debtToBeRemovedToGetBackToTarget
+						.mul(nonEscrowedBalance)
+						.div(snxToBeLiquidatedToGetBackToTarget)
+				: debtToBeRemovedToGetBackToTarget;
+			return debtBalance.sub(debtToBeRemoved);
+		}
+		return debtBalance;
+	};
+	const getChangedCollateral = () => {
+		if (buttonDisplaying !== 'SELF_LIQUIDATION_BUTTON') return stakedCollateral;
+		const snxToBeLiquidated = snxToBeLiquidatedToGetBackToTarget.gt(nonEscrowedBalance)
+			? nonEscrowedBalance
+			: snxToBeLiquidatedToGetBackToTarget;
+		return collateral.sub(snxToBeLiquidated);
+	};
+	const changedDebt = getChangedDebt();
+	const changedCollateral = getChangedCollateral();
+	const changedCRatio = changedDebt.eq(0)
+		? wei(0)
+		: changedCollateral.div(changedDebt.div(SNXRate));
+
+	return {
+		changedDebt,
+		changedCRatio,
+		changedCollateral,
+	};
+};

--- a/translations/en.json
+++ b/translations/en.json
@@ -366,6 +366,10 @@
 				"title": "Clear debt by buying more sUSD via 1inch",
 				"subtitle": "Burn your sUSD to unlock your staked SNX and clear your debt. As you don’t have enough sUSD, buy more with ETH in the left form. <0>Learn more.</0>"
 			},
+			"self-liquidate": {
+				"title": "Self Liquidate",
+				"subtitle": ""
+			},
 			"table": {
 				"total-snx": "Total",
 				"not-staked": "Not Staked",


### PR DESCRIPTION
Adds a side panel with calculation of how your collateral/ debt / c-ratio will change from the self liquidation ui.
There's a few different calc:
When burn max button is visible:
![Screen Shot 2022-06-02 at 3 57 48 pm](https://user-images.githubusercontent.com/5688912/171562795-7b2d7be7-36eb-498b-86b0-c598ee43c6bf.png)
When self liquidation button is visible and we have enough non escrowed SNX
![Screen Shot 2022-06-02 at 1 16 24 pm](https://user-images.githubusercontent.com/5688912/171562951-fb6a5b3e-f701-4837-8200-a8e53f0567c1.png)
When self liquidation button is visible and we DONT have enough non escrowed SNX
![Screen Shot 2022-06-02 at 1 16 46 pm](https://user-images.githubusercontent.com/5688912/171562997-1c96f8f8-25ae-4e5f-810e-af98ad362707.png)
No button visible:
![Screen Shot 2022-06-02 at 3 54 44 pm](https://user-images.githubusercontent.com/5688912/171563071-a4be19f2-7899-4cdc-969b-fd49ea62d09a.png)


