### PR TITLE
The balanceMap type is wrong. Sometimes sUSD is undefined

### DIFF
--- a/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
@@ -73,7 +73,7 @@ const HedgeTabOptimism = () => {
 	);
 
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
-	const sUSDBalance = synthsBalancesQuery.data?.balancesMap.sUSD.balance || wei(0);
+	const sUSDBalance = synthsBalancesQuery.data?.balancesMap.sUSD?.balance || wei(0);
 	const dSNXBalanceQuery = useGetDSnxBalance();
 	const dSNXBalance = dSNXBalanceQuery.data;
 


### PR DESCRIPTION
This fixes the problem. Will look into fixing the type of the balanceMap in `js-monorepo` too