### PR TITLE
Debt over time fixes

### DIFF
--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -55,11 +55,11 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 	if (!isLoaded) {
 		return { isLoading: true, data: [] };
 	}
-	let issuesAndBurns = issues.data!.map((b) => ({ isBurn: false, ...b }));
-	issuesAndBurns = sortBy(
-		issuesAndBurns.concat(burns.data!.map((b) => ({ isBurn: true, ...b }))),
-		(d) => d.timestamp.toNumber()
-	);
+	const issueData = issues.data || [];
+	const burnData = burns.data || [];
+	const issuesWithFlag = issueData.map((b) => ({ isBurn: false, ...b }));
+	const burnWithFlag = burnData.map((b) => ({ isBurn: true, ...b }));
+	const issuesAndBurns = sortBy(issuesWithFlag.concat(burnWithFlag), (d) => d.timestamp.toNumber());
 
 	const debtHistory = debtSnapshot.data ?? [];
 

--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -55,8 +55,8 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 	if (!isLoaded) {
 		return { isLoading: true, data: [] };
 	}
-	const issueData = issues.data || [];
-	const burnData = burns.data || [];
+	const issueData = issues.data ?? [];
+	const burnData = burns.data ?? [];
 	const issuesWithFlag = issueData.map((b) => ({ isBurn: false, ...b }));
 	const burnWithFlag = burnData.map((b) => ({ isBurn: true, ...b }));
 	const issuesAndBurns = sortBy(issuesWithFlag.concat(burnWithFlag), (d) => d.timestamp.toNumber());
@@ -82,7 +82,7 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 			return {
 				timestamp: debtSnapshot.timestamp.toNumber() * 1000,
 				issuanceDebt: historicalIssuanceAggregation[i],
-				actualDebt: wei(debtSnapshot.debtBalanceOf || 0),
+				actualDebt: wei(debtSnapshot.debtBalanceOf ?? 0),
 				index: i,
 			};
 		}
@@ -94,7 +94,7 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 		// We only want this to happen if we have some history, so that we can display no data for accounts that never have staked
 		historicalDebtAndIssuance.push({
 			timestamp: new Date().getTime(),
-			actualDebt: debtDataQuery.data?.debtBalance || wei(0),
+			actualDebt: debtDataQuery.data?.debtBalance ?? wei(0),
 			issuanceDebt: last(historicalIssuanceAggregation) ?? wei(0),
 			index: historicalDebtAndIssuance.length,
 		});

--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -88,14 +88,17 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 		}
 	);
 
-	// Last occurrence is the current state of the debt
-	// Issuance debt = last occurrence of the historicalDebtAndIssuance array
-	historicalDebtAndIssuance.push({
-		timestamp: new Date().getTime(),
-		actualDebt: debtDataQuery.data?.debtBalance || wei(0),
-		issuanceDebt: last(historicalIssuanceAggregation) ?? wei(0),
-		index: historicalDebtAndIssuance.length,
-	});
+	if (historicalDebtAndIssuance.length > 0) {
+		// Last occurrence is the current state of the debt
+		// Issuance debt = last occurrence of the historicalDebtAndIssuance array
+		// We only want this to happen if we have some history, so that we can display no data for accounts that never have staked
+		historicalDebtAndIssuance.push({
+			timestamp: new Date().getTime(),
+			actualDebt: debtDataQuery.data?.debtBalance || wei(0),
+			issuanceDebt: last(historicalIssuanceAggregation) ?? wei(0),
+			index: historicalDebtAndIssuance.length,
+		});
+	}
 
 	return { isLoading: false, data: historicalDebtAndIssuance };
 };

--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -53,7 +53,7 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 		issues.isSuccess && burns.isSuccess && debtSnapshot.isSuccess && debtDataQuery.isSuccess;
 
 	if (!isLoaded) {
-		return { isLoading: false, data: [] };
+		return { isLoading: true, data: [] };
 	}
 	let issuesAndBurns = issues.data!.map((b) => ({ isBurn: false, ...b }));
 	issuesAndBurns = sortBy(

--- a/hooks/useHistoricalDebtData.ts
+++ b/hooks/useHistoricalDebtData.ts
@@ -41,7 +41,7 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 		{
 			first: 1000,
 			orderBy: 'timestamp',
-			orderDirection: 'desc',
+			orderDirection: 'asc',
 			where: { account: walletAddress?.toLowerCase() },
 		},
 		{ timestamp: true, debtBalanceOf: true }
@@ -67,7 +67,7 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 	// values of every mint and burns
 	const historicalIssuanceAggregation: Wei[] = [];
 
-	issuesAndBurns.slice().forEach((event) => {
+	issuesAndBurns.forEach((event) => {
 		const multiplier = event.isBurn ? -1 : 1;
 		const aggregation = event.value
 			.mul(multiplier)
@@ -77,18 +77,16 @@ const useHistoricalDebtData = (walletAddress: string | null): HistoricalDebtAndI
 	});
 
 	// We merge both actual & issuance debt into an array
-	let historicalDebtAndIssuance: HistoricalDebtAndIssuanceData[] = [];
-	debtHistory
-		.slice()
-		.reverse()
-		.forEach((debtSnapshot, i) => {
-			historicalDebtAndIssuance.push({
+	const historicalDebtAndIssuance: HistoricalDebtAndIssuanceData[] = debtHistory.map(
+		(debtSnapshot, i) => {
+			return {
 				timestamp: debtSnapshot.timestamp.toNumber() * 1000,
 				issuanceDebt: historicalIssuanceAggregation[i],
 				actualDebt: wei(debtSnapshot.debtBalanceOf || 0),
 				index: i,
-			});
-		});
+			};
+		}
+	);
 
 	// Last occurrence is the current state of the debt
 	// Issuance debt = last occurrence of the historicalDebtAndIssuance array

--- a/sections/debt/components/DebtChart/DebtChart.tsx
+++ b/sections/debt/components/DebtChart/DebtChart.tsx
@@ -88,12 +88,13 @@ const DebtChart = ({ data, isLoading }: { data: Data[]; isLoading: boolean }) =>
 		);
 	}
 
-	if (isLoading)
+	if (isLoading) {
 		return (
 			<DefaultContainer>
 				<Spinner src={SpinnerIcon} />
 			</DefaultContainer>
 		);
+	}
 	if (!data || data.length === 0)
 		return <DefaultContainer>{t('debt.actions.track.no-data')}</DefaultContainer>;
 

--- a/sections/debt/components/OverviewTab/index.tsx
+++ b/sections/debt/components/OverviewTab/index.tsx
@@ -39,7 +39,7 @@ const OverviewTab = () => {
 					</ContainerHeaderSection>
 				</ContainerHeader>
 				<ContainerBody>
-					<DebtChart data={historicalDebt.data} isLoading={false} />
+					<DebtChart data={historicalDebt.data} isLoading={historicalDebt.isLoading} />
 				</ContainerBody>
 			</Container>
 		</>


### PR DESCRIPTION
- This make sure we show a loader when loading. Previously it would say "Debt data is not available for this wallet" while loading.
- When connecting with an account that never have staked a "broken" chart would be shown, now it will display:  "Debt data is not available for this wallet"
- Also some refactor in `hooks/useHistoricalDebtData.ts` to make it a little cleare

"Broken" chart that got fixed: 
<img width="999" alt="Screen Shot 2022-06-08 at 11 32 23 am" src="https://user-images.githubusercontent.com/5688912/172512445-39d97aa3-38f3-44ff-b994-ba021f763fb3.png">
