### PR TITLE
Fix transferable amount when burining max

### DIFF
--- a/sections/staking/components/StakingInfo/BurnInfo.tsx
+++ b/sections/staking/components/StakingInfo/BurnInfo.tsx
@@ -141,7 +141,6 @@ const BurnInfo: FC = () => {
 		debtEscrowBalance,
 		sUSDBalance,
 	]);
-	console.log('amountToBurn', amountToBurn);
 	const isInputEmpty = amountToBurn.length === 0;
 
 	return (

--- a/sections/staking/components/helper.test.ts
+++ b/sections/staking/components/helper.test.ts
@@ -28,7 +28,7 @@ describe('staking helpers', () => {
 		expect(result.toString(0)).toBe('50');
 	});
 	test('getTransferableAmountFromBurn', () => {
-		const amountToBurn = 100;
+		const amountToBurn = wei(100);
 		const debtEscrowBalance = wei(50);
 		const targetCRatio = wei(0.25);
 		const SNXPrice = wei(10);

--- a/sections/staking/components/helper.ts
+++ b/sections/staking/components/helper.ts
@@ -16,7 +16,7 @@ export function getTransferableAmountFromMint(balance: Wei, stakedValue: Wei): W
 }
 
 export function getTransferableAmountFromBurn(
-	amountToBurn: WeiSource,
+	amountToBurn: Wei,
 	debtEscrowBalance: Wei,
 	targetCRatio: Wei,
 	SNXPrice: Wei,


### PR DESCRIPTION
 When users use BURN MAX we send off the complete sUSD balance to the contract.
 The contract will only burn whats needed. We do this to avoid sUSD dust in the wallet.
 When the sUSD balance is bigger than the debt balance these calculations will be wrong
 So, when that's the case, use the debt balance for the calculations