### PR TITLE
[NOT READY TO MERGE] Use burnToTarget in selfLiquidation burn max button

### DIFF
--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidationTabContent.tsx
@@ -126,7 +126,10 @@ const SelfLiquidationTabContent: React.FC<{
 						{t('staking.self-liquidation.info.balance-not-zero')}
 					</InfoText>
 					<ButtonWrapper>
-						<BurnMaxButton amountToBurn={sUSDBalance} />
+						<BurnMaxButton
+							sUSDBalance={sUSDBalance}
+							burnAmountToFixCRatio={burnAmountToFixCRatio}
+						/>
 					</ButtonWrapper>
 				</>
 			) : (


### PR DESCRIPTION
- We do this to avoid the minStake time check in the Issuer contract