### PR TITLE
getButtonDisplaying needs to look at canBurn too

### DIFF
--- a/hooks/useGetCanBurn.ts
+++ b/hooks/useGetCanBurn.ts
@@ -1,0 +1,21 @@
+import Connector from 'containers/Connector';
+import { useQuery, UseQueryOptions } from 'react-query';
+
+const useGetCanBurn = (walletAddress: string | null, options?: UseQueryOptions<Boolean>) => {
+	const { synthetixjs } = Connector.useContainer();
+	const Issuer = synthetixjs?.contracts.Issuer;
+	return useQuery(
+		['canBurn', Issuer?.address, walletAddress],
+		() => {
+			if (!Issuer) {
+				throw Error('Expected Issuer contract to be defined');
+			}
+			return Issuer.canBurnSynths(walletAddress);
+		},
+		{
+			enabled: Boolean(Issuer && walletAddress),
+			...options,
+		}
+	);
+};
+export default useGetCanBurn;

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -13,28 +13,7 @@ import Connector from 'containers/Connector';
 import styled from 'styled-components';
 import { FlexDivJustifyCenter } from 'styles/common';
 import Loader from 'components/Loader';
-import { useQuery } from 'react-query';
-
-/**
- * Ideally the Issuer should always let us burn when we're burning an amount that wont get the c-ration back to target
- * But since it doesn't support this, we need to check that we actually can burn
- */
-const useGetCanBurn = (walletAddress: string | null) => {
-	const { synthetixjs } = Connector.useContainer();
-	const Issuer = synthetixjs?.contracts.Issuer;
-	return useQuery(
-		['canBurn', Issuer?.address, walletAddress],
-		() => {
-			if (!Issuer) {
-				throw Error('Expected Issuer contract to be defined');
-			}
-			return Issuer.canBurnSynths(walletAddress);
-		},
-		{
-			enabled: Boolean(Issuer && walletAddress),
-		}
-	);
-};
+import useGetCanBurn from 'hooks/useGetCanBurn';
 
 const SelfLiquidateTab = () => {
 	const walletAddress = useRecoilValue(walletAddressState);
@@ -49,6 +28,10 @@ const SelfLiquidateTab = () => {
 		isLoading,
 	} = useStakingCalculations();
 	const { connectWallet } = Connector.useContainer();
+	/**
+	 * Ideally the Issuer should always let us burn when we're burning an amount that wont get the c-ration back to target
+	 * But since it doesn't support this, we need to check that we actually can burn
+	 */
 	const canBurnQuery = useGetCanBurn(walletAddress);
 	const { useSynthsBalancesQuery, useGetLiquidationDataQuery } = useSynthetixQueries();
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);

--- a/sections/staking/components/StakingInfo/SelfLiquidationInfo.tsx
+++ b/sections/staking/components/StakingInfo/SelfLiquidationInfo.tsx
@@ -1,6 +1,7 @@
 import useSynthetixQueries from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
 import { CryptoCurrency, Synths } from 'constants/currency';
+import useGetCanBurn from 'hooks/useGetCanBurn';
 import useGetSnxAmountToBeLiquidatedUsd from 'hooks/useGetSnxAmountToBeLiquidatedUsd';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +27,7 @@ const SelfLiquidationInfo = () => {
 	const { useSynthsBalancesQuery, useGetLiquidationDataQuery } = useSynthetixQueries();
 
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
+	const canBurnQuery = useGetCanBurn(walletAddress);
 
 	const sUSDBalance = synthsBalancesQuery?.data?.balancesMap[Synths.sUSD]?.balance ?? wei(0);
 	const buttonDisplaying = getButtonDisplaying({
@@ -33,6 +35,7 @@ const SelfLiquidationInfo = () => {
 		debtBalance,
 		percentageCurrentCRatio,
 		percentageTargetCRatio,
+		canBurn: canBurnQuery.data,
 	});
 	const liqData = useGetLiquidationDataQuery(walletAddress, {
 		enabled: buttonDisplaying === 'SELF_LIQUIDATION_BUTTON',

--- a/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.test.ts
+++ b/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.test.ts
@@ -9,8 +9,29 @@ describe('selfLiquidationCalculations', () => {
 				percentageTargetCRatio: wei(3),
 				sUSDBalance: wei(100),
 				debtBalance: wei(150),
+				canBurn: true,
 			});
 			expect(result).toBe('BURN_MAX_BUTTON');
+		});
+		test('burn max button not displaying since can burn is undefined', () => {
+			const result = getButtonDisplaying({
+				percentageCurrentCRatio: wei(2),
+				percentageTargetCRatio: wei(3),
+				sUSDBalance: wei(100),
+				debtBalance: wei(150),
+				canBurn: undefined,
+			});
+			expect(result).toBe(undefined);
+		});
+		test('burn max button not displaying since can burn is false', () => {
+			const result = getButtonDisplaying({
+				percentageCurrentCRatio: wei(2),
+				percentageTargetCRatio: wei(3),
+				sUSDBalance: wei(100),
+				debtBalance: wei(150),
+				canBurn: false,
+			});
+			expect(result).toBe(undefined);
 		});
 		test('self liquidation button', () => {
 			const result = getButtonDisplaying({

--- a/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.ts
+++ b/sections/staking/components/StakingInfo/selfLiquidationInfoCalculations.ts
@@ -5,11 +5,13 @@ export const getButtonDisplaying = ({
 	percentageCurrentCRatio,
 	sUSDBalance,
 	debtBalance,
+	canBurn,
 }: {
 	percentageTargetCRatio: Wei;
 	percentageCurrentCRatio: Wei;
 	sUSDBalance: Wei;
 	debtBalance: Wei;
+	canBurn?: Boolean;
 }) => {
 	const notStaking = percentageCurrentCRatio.eq(0);
 	if (notStaking) return undefined;
@@ -18,7 +20,7 @@ export const getButtonDisplaying = ({
 	const selfLiquidateButtonDisplaying = sUSDBalance.eq(0);
 
 	if (selfLiquidateButtonDisplaying) return 'SELF_LIQUIDATION_BUTTON';
-	const burnMaxButtonIsDisplaying = sUSDBalance.gt(0) && sUSDBalance.lt(debtBalance);
+	const burnMaxButtonIsDisplaying = sUSDBalance.gt(0) && sUSDBalance.lt(debtBalance) && canBurn;
 	if (burnMaxButtonIsDisplaying) return 'BURN_MAX_BUTTON';
 	return undefined;
 };


### PR DESCRIPTION
Missed updating the liquidation side panel with the new `canBurn` logic.
Related PR: #1126 