### PR TITLE
Optimise contracts by cleaning up deployments JSON

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 const withPlugins = require('next-compose-plugins');
 const optimizedImages = require('next-optimized-images');
 
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+	enabled: process.env.GENERATE_BUNDLE_REPORT === 'true',
+});
+
 function optimiseContracts(config, { webpack }) {
 	const networks = ['kovan', 'kovan-ovm', 'mainnet', 'mainnet-ovm'];
 	const generate = require('./scripts/minify-synthetix-contract');
@@ -27,43 +31,32 @@ function optimiseContracts(config, { webpack }) {
 	);
 }
 
-function generateBundleReport(config) {
-	if (process.env.GENERATE_BUNDLE_REPORT === 'true') {
-		const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-		const plugin = new BundleAnalyzerPlugin({
-			analyzerMode: 'static',
-			reportFilename: 'reports/webpack.html',
-			openAnalyzer: false,
-			generateStatsFile: false,
-		});
-		config.plugins.push(plugin);
+module.exports = withPlugins(
+	[[optimizedImages, { images: { optimize: false } }], withBundleAnalyzer],
+	{
+		webpack: (config, context) => {
+			config.resolve.mainFields = ['module', 'browser', 'main'];
+			optimiseContracts(config, context);
+			return config;
+		},
+		trailingSlash: !!process.env.NEXT_PUBLIC_TRAILING_SLASH_ENABLED,
+		exportPathMap: function (defaultPathMap) {
+			return {
+				...defaultPathMap,
+
+				// all the dynamic pages need to be defined here (this needs to be imported from the routes)
+				'/staking': { page: '/staking/[[...action]]' },
+				'/staking/burn': { page: '/staking/[[...action]]' },
+				'/staking/mint': { page: '/staking/[[...action]]' },
+
+				'/earn': { page: '/earn/[[...pool]]' },
+				'/earn/claim': { page: '/earn/[[...pool]]' },
+				'/earn/curve-LP': { page: '/earn/[[...pool]]' },
+				'/earn/iBTC-LP': { page: '/earn/[[...pool]]' },
+				'/earn/iETH-LP': { page: '/earn/[[...pool]]' },
+
+				'/pools/weth-snx': { page: '/pools/[[...pool]]' },
+			};
+		},
 	}
-}
-
-module.exports = withPlugins([[optimizedImages, { images: { optimize: false } }]], {
-	webpack: (config, context) => {
-		config.resolve.mainFields = ['module', 'browser', 'main'];
-		generateBundleReport(config, context);
-		optimiseContracts(config, context);
-		return config;
-	},
-	trailingSlash: !!process.env.NEXT_PUBLIC_TRAILING_SLASH_ENABLED,
-	exportPathMap: function (defaultPathMap) {
-		return {
-			...defaultPathMap,
-
-			// all the dynamic pages need to be defined here (this needs to be imported from the routes)
-			'/staking': { page: '/staking/[[...action]]' },
-			'/staking/burn': { page: '/staking/[[...action]]' },
-			'/staking/mint': { page: '/staking/[[...action]]' },
-
-			'/earn': { page: '/earn/[[...pool]]' },
-			'/earn/claim': { page: '/earn/[[...pool]]' },
-			'/earn/curve-LP': { page: '/earn/[[...pool]]' },
-			'/earn/iBTC-LP': { page: '/earn/[[...pool]]' },
-			'/earn/iETH-LP': { page: '/earn/[[...pool]]' },
-
-			'/pools/weth-snx': { page: '/pools/[[...pool]]' },
-		};
-	},
-});
+);

--- a/next.config.js
+++ b/next.config.js
@@ -1,20 +1,50 @@
-// next.config.js
 const withPlugins = require('next-compose-plugins');
 const optimizedImages = require('next-optimized-images');
 
+function optimiseContracts(config, { webpack }) {
+	const networks = ['kovan', 'kovan-ovm', 'mainnet', 'mainnet-ovm'];
+	const generate = require('./scripts/minify-synthetix-contract');
+	const out = require('path').resolve(__dirname, '.next/tmp');
+	require('fs').mkdirSync(out, { recursive: true });
+	generate({ networks, out });
+
+	networks.forEach((network) =>
+		config.plugins.push(
+			new webpack.NormalModuleReplacementPlugin(
+				new RegExp(`/synthetix/publish/deployed/${network}/deployment.json`),
+				require.resolve(`${out}/${network}.json`)
+			)
+		)
+	);
+	config.plugins.push(
+		new webpack.NormalModuleReplacementPlugin(
+			new RegExp(`/synthetix/publish/deployed/(goerli|local)`),
+			require.resolve('./scripts/noop')
+		)
+	);
+	config.plugins.push(
+		new webpack.NormalModuleReplacementPlugin(/^synthetix$/, require.resolve('synthetix/index.js'))
+	);
+}
+
+function generateBundleReport(config) {
+	if (process.env.GENERATE_BUNDLE_REPORT === 'true') {
+		const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+		const plugin = new BundleAnalyzerPlugin({
+			analyzerMode: 'static',
+			reportFilename: 'reports/webpack.html',
+			openAnalyzer: false,
+			generateStatsFile: false,
+		});
+		config.plugins.push(plugin);
+	}
+}
+
 module.exports = withPlugins([[optimizedImages, { images: { optimize: false } }]], {
-	webpack: (config) => {
+	webpack: (config, context) => {
 		config.resolve.mainFields = ['module', 'browser', 'main'];
-		if (process.env.GENERATE_BUNDLE_REPORT === 'true') {
-			const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-			const plugin = new BundleAnalyzerPlugin({
-				analyzerMode: 'static',
-				reportFilename: 'reports/webpack.html',
-				openAnalyzer: false,
-				generateStatsFile: false,
-			});
-			config.plugins.push(plugin);
-		}
+		generateBundleReport(config, context);
+		optimiseContracts(config, context);
 		return config;
 	},
 	trailingSlash: !!process.env.NEXT_PUBLIC_TRAILING_SLASH_ENABLED,

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"@babel/preset-typescript": "^7.17.12",
 		"@metamask/providers": "^8.1.1",
 		"@microsoft/eslint-formatter-sarif": "^3.0.0",
+		"@next/bundle-analyzer": "^10.2.3",
 		"@synthetixio/synpress": "^1.1.1",
 		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^12.1.5",
@@ -145,8 +146,7 @@
 		"svg-jest": "^1.0.1",
 		"typescript": "^4.7.4",
 		"url-loader": "^4.1.1",
-		"webp-loader": "^0.6.0",
-		"webpack-bundle-analyzer": "^4.5.0"
+		"webp-loader": "^0.6.0"
 	},
 	"resolutions": {
 		"eslint-plugin-prettier": "^4.0.0",

--- a/scripts/minify-synthetix-contract.js
+++ b/scripts/minify-synthetix-contract.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const ethers = require('ethers');
+
+module.exports = function generate({ networks, out }) {
+	networks.forEach((network) => {
+		const deployment = require(`synthetix/publish/deployed/${network}/deployment.json`);
+
+		Object.keys(deployment.targets).forEach((key) => {
+			const { name, source, address } = deployment.targets[key];
+			deployment.targets[key] = { name, source, address };
+		});
+
+		Object.keys(deployment.sources).forEach((key) => {
+			const source = deployment.sources[key];
+			const iface = new ethers.utils.Interface(source.abi);
+			const abi = iface.format(ethers.utils.FormatTypes.full);
+			deployment.sources[key] = { abi };
+		});
+
+		fs.writeFileSync(`${out}/${network}.json`, JSON.stringify(deployment, null, 2));
+	});
+};

--- a/scripts/noop.js
+++ b/scripts/noop.js
@@ -1,0 +1,3 @@
+(function (exports) {
+	exports.noop = function () {};
+})(typeof module === 'object' && typeof module.exports === 'object' ? module.exports : window);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3213,6 +3213,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/bundle-analyzer@npm:^10.2.3":
+  version: 10.2.3
+  resolution: "@next/bundle-analyzer@npm:10.2.3"
+  dependencies:
+    webpack-bundle-analyzer: 4.3.0
+  checksum: 1b2fb40e60699c70f99db502e394aa67972f944a617222383629a6b78947bd716d487e51a9e42e7d145470b436354aa29c4ddb4ca1449c931c1ad9efa21c3d4b
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:10.2.3":
   version: 10.2.3
   resolution: "@next/env@npm:10.2.3"
@@ -9435,10 +9444,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
+"commander@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "commander@npm:6.2.1"
+  checksum: d7090410c0de6bc5c67d3ca41c41760d6d268f3c799e530aafb73b7437d1826bbf0d2a3edac33f8b57cc9887b4a986dce307fa5557e109be40eadb7c43b21742
   languageName: node
   linkType: hard
 
@@ -23503,6 +23512,7 @@ jschardet@latest:
     "@babel/preset-typescript": ^7.17.12
     "@metamask/providers": ^8.1.1
     "@microsoft/eslint-formatter-sarif": ^3.0.0
+    "@next/bundle-analyzer": ^10.2.3
     "@reach/dialog": ^0.15.3
     "@snapshot-labs/snapshot.js": ^0.3.22
     "@synthetixio/assets": ^2.0.13
@@ -23614,7 +23624,6 @@ jschardet@latest:
     unstated-next: ^1.1.0
     url-loader: ^4.1.1
     webp-loader: ^0.6.0
-    webpack-bundle-analyzer: ^4.5.0
   languageName: unknown
   linkType: soft
 
@@ -26559,14 +26568,14 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "webpack-bundle-analyzer@npm:4.5.0"
+"webpack-bundle-analyzer@npm:4.3.0":
+  version: 4.3.0
+  resolution: "webpack-bundle-analyzer@npm:4.3.0"
   dependencies:
     acorn: ^8.0.4
     acorn-walk: ^8.0.0
     chalk: ^4.1.0
-    commander: ^7.2.0
+    commander: ^6.2.0
     gzip-size: ^6.0.0
     lodash: ^4.17.20
     opener: ^1.5.2
@@ -26574,7 +26583,7 @@ jschardet@latest:
     ws: ^7.3.1
   bin:
     webpack-bundle-analyzer: lib/bin/analyzer.js
-  checksum: 158e96810ec213d5665ca1c0b257097db44e1f11c4befefab8352b9e5b10890fcb3e3fc1f7bb400dd58762a8edce5621c92afeca86eb4687d2eb64e93186bfcb
+  checksum: 00b7bf4ac9fca17062b66b6897145b94e87153d3ec8815f0e0c05a3b8a1ca75320262db01a5fa634f604ee3d41aecde1ee59838d05b6d03cd5be62eb1addbcf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Replace synthetix (resolves to precompiled `browser.js` by default) with synthetix source so we can control compilation
- Stub imports of unsupported networks (we only support mainnet and kovan + ovm)
- Cleanup deployments.json for each supported network (cleanup unused fields and replace abi with non-json readable format)

On a clean `test.js` file importing synthetix resulsted in this:
```sh
# before:
asset test.out.js 9.51 MiB [emitted] (name: main)

# after:
asset test.out.js 2.59 MiB [emitted] (name: main)
```

## Big browserjs chunk is gone! Size is down significantly

Well, it is still massive, but improvements is definitely there!

<img width="1902" alt="image" src="https://user-images.githubusercontent.com/28145325/177700054-4169daf6-01ad-4f61-8de9-8c4352e8079d.png">

PS: Need to extract synthetix into its own chunk btw. Seems like there is a bit too much duplication


## Testing on Kovan
<img width="986" alt="image" src="https://user-images.githubusercontent.com/28145325/177701096-3c7472b6-1078-4a08-97e4-5de697809c55.png">

