### PR TITLE
Better comma fix

### DIFF
--- a/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
@@ -81,7 +81,7 @@ const HedgeTabOptimism = () => {
 	const depositTx = useContractTxn(
 		dSNXPoolContractOptimism,
 		'deposit',
-		[sUSDContract?.address, wei(amountToSend.replaceAll(',', '') || 0).toBN()],
+		[sUSDContract?.address, wei(amountToSend || 0).toBN()],
 		depositGasCost,
 		{
 			onSuccess: () => {
@@ -94,7 +94,7 @@ const HedgeTabOptimism = () => {
 	);
 	const dSnxAmount =
 		amountToSend && dSNXPrice
-			? formatCryptoCurrency(wei(amountToSend.replaceAll(',', '')).div(dSNXPrice), {
+			? formatCryptoCurrency(wei(amountToSend).div(dSNXPrice), {
 					maxDecimals: 1,
 					minDecimals: 2,
 			  })
@@ -125,7 +125,7 @@ const HedgeTabOptimism = () => {
 							setAmountToSend(e.target.value);
 						} catch {}
 					}}
-					value={amountToSend.replaceAll(',', '')}
+					value={amountToSend}
 					autoFocus={true}
 				/>
 				<StyledBalance>
@@ -197,7 +197,7 @@ const HedgeTabOptimism = () => {
 						approved ? depositTx.mutate() : approveTx.mutate();
 					}}
 					variant="primary"
-					disabled={wei(amountToSend.replaceAll(',', '') || '0').eq(0)}
+					disabled={wei(amountToSend || '0').eq(0)}
 				>
 					{approved ? t('debt.actions.manage.swap') : t('debt.actions.manage.approve')}
 				</StyledButton>

--- a/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
@@ -46,6 +46,7 @@ const HedgeTabOptimism = () => {
 
 	const sUSDContract = synthetixjs?.contracts.SynthsUSD;
 	const [amountToSend, setAmountToSend] = useState('');
+	const [sendMax, setSendMax] = useState(false);
 	const [approveGasCost, setApproveGasCost] = useState<GasPrice | undefined>(undefined);
 	const [depositGasCost, setDepositGasCost] = useState<GasPrice | undefined>(undefined);
 
@@ -77,11 +78,11 @@ const HedgeTabOptimism = () => {
 	const sUSDBalance = synthsBalancesQuery.data?.balancesMap.sUSD?.balance || wei(0);
 	const dSNXBalanceQuery = useGetDSnxBalance();
 	const dSNXBalance = dSNXBalanceQuery.data;
-
+	const actualAmountToSendBn = sendMax ? sUSDBalance.toBN() : wei(amountToSend || 0).toBN();
 	const depositTx = useContractTxn(
 		dSNXPoolContractOptimism,
 		'deposit',
-		[sUSDContract?.address, wei(amountToSend || 0).toBN()],
+		[sUSDContract?.address, actualAmountToSendBn],
 		depositGasCost,
 		{
 			onSuccess: () => {
@@ -122,10 +123,11 @@ const HedgeTabOptimism = () => {
 						try {
 							const val = utils.parseUnits(e.target.value || '0', 18);
 							if (val.gte(constants.MaxUint256)) return;
+							setSendMax(false);
 							setAmountToSend(e.target.value);
 						} catch {}
 					}}
-					value={amountToSend}
+					value={sendMax ? sUSDBalance.toString(2) : amountToSend}
 					autoFocus={true}
 				/>
 				<StyledBalance>
@@ -140,7 +142,7 @@ const HedgeTabOptimism = () => {
 						disabled={approveTx.isLoading || depositTx.isLoading}
 						onClick={() => {
 							if (sUSDBalance?.gt(0)) {
-								setAmountToSend(sUSDBalance.toString(2));
+								setSendMax(true);
 							}
 						}}
 					>

--- a/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
@@ -38,6 +38,7 @@ import {
 } from 'styles/common';
 import { EXTERNAL_LINKS } from 'constants/links';
 import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
+import WarningIcon from 'assets/svg/app/warning.svg';
 
 const HedgeTabOptimism = () => {
 	const { t } = useTranslation();
@@ -192,17 +193,25 @@ const HedgeTabOptimism = () => {
 				</LoaderContainer>
 			)}
 			{Boolean(!approveTx.isLoading && !depositTx.isLoading) && (
-				<StyledButton
-					size="lg"
-					onClick={() => {
-						setTxModalOpen(true);
-						approved ? depositTx.mutate() : approveTx.mutate();
-					}}
-					variant="primary"
-					disabled={wei(amountToSend || '0').eq(0)}
-				>
-					{approved ? t('debt.actions.manage.swap') : t('debt.actions.manage.approve')}
-				</StyledButton>
+				<>
+					{depositTx.errorMessage && (
+						<ErrorText>
+							<Svg width={30} height={40} src={WarningIcon} />
+							{depositTx.errorMessage}
+						</ErrorText>
+					)}
+					<StyledButton
+						size="lg"
+						onClick={() => {
+							setTxModalOpen(true);
+							approved ? depositTx.mutate() : approveTx.mutate();
+						}}
+						variant="primary"
+						disabled={wei(amountToSend || '0').eq(0) || Boolean(depositTx.errorMessage)}
+					>
+						{approved ? t('debt.actions.manage.swap') : t('debt.actions.manage.approve')}
+					</StyledButton>
+				</>
 			)}
 			<PoweredByContainer>
 				{t('debt.actions.manage.powered-by')}{' '}
@@ -240,6 +249,14 @@ const Container = styled.div`
 	height: 100%;
 `;
 
+const ErrorText = styled.p`
+	color: white;
+	text-transform: none;
+	font-size: 14px;
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+`;
 const LoaderContainer = styled.div`
 	display: flex;
 	align-items: center;

--- a/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
@@ -140,12 +140,7 @@ const HedgeTabOptimism = () => {
 						disabled={approveTx.isLoading || depositTx.isLoading}
 						onClick={() => {
 							if (sUSDBalance?.gt(0)) {
-								setAmountToSend(
-									formatCryptoCurrency(sUSDBalance || wei(0), {
-										maxDecimals: 1,
-										minDecimals: 2,
-									})
-								);
+								setAmountToSend(sUSDBalance.toString(2));
 							}
 						}}
 					>


### PR DESCRIPTION
I introduced a new `sendMax` state. If that is set to true we just use the sUSD balance directly. This state gets sets to true when clicking the max button and back to false if the users types in the input field.

This solution removed the need for replaceAll but also fixes a rounding bug.
The bug: We were converting the max amount to a two decimal string by rounding which meant in some cases we round up and try to deposit more than the sUSD balance. 

A also added an error message and disable the deposit button when we have an error:
<img width="454" alt="Screen Shot 2022-07-07 at 11 01 02 am" src="https://user-images.githubusercontent.com/5688912/177736814-09be5a27-6c7c-441f-808d-9a6bcd82a741.png">

