### PR TITLE
Hedge tab max button bug

### DIFF
--- a/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/HedgeTabOptimism.tsx
@@ -207,7 +207,7 @@ const HedgeTabOptimism = () => {
 							approved ? depositTx.mutate() : approveTx.mutate();
 						}}
 						variant="primary"
-						disabled={wei(amountToSend || '0').eq(0) || Boolean(depositTx.errorMessage)}
+						disabled={wei(actualAmountToSendBn || '0').eq(0) || Boolean(depositTx.errorMessage)}
 					>
 						{approved ? t('debt.actions.manage.swap') : t('debt.actions.manage.approve')}
 					</StyledButton>


### PR DESCRIPTION
Disable logic should be based on 'actualAmountToSendBn'
Without this the button will be disabled if user only click the max button. 