### PR TITLE
Reduce content popping

### DIFF
--- a/components/GlobalLoader/GlobalLoader.tsx
+++ b/components/GlobalLoader/GlobalLoader.tsx
@@ -1,0 +1,50 @@
+import Colors from 'styles/theme/colors';
+
+export function GlobalLoader() {
+	const size = 50;
+	return (
+		<svg
+			viewBox="0 0 38 38"
+			xmlns="http://www.w3.org/2000/svg"
+			style={{
+				width: `${size}px`,
+				height: `${size}px`,
+				left: '50%',
+				top: '50%',
+				marginTop: `-${size / 2}px`,
+				marginLeft: `-${size / 2}px`,
+				position: 'fixed',
+			}}
+		>
+			<defs>
+				<linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+					<stop stop-color={Colors.blueHover} stop-opacity="0" offset="0%" />
+					<stop stop-color={Colors.blueHover} stop-opacity=".631" offset="63.146%" />
+					<stop stop-color={Colors.blueHover} offset="100%" />
+				</linearGradient>
+			</defs>
+			<g transform="translate(1 1)" fill="none" fill-rule="evenodd">
+				<path d="M36 18c0-9.94-8.06-18-18-18" stroke="url(#a)" stroke-width="2">
+					<animateTransform
+						attributeName="transform"
+						type="rotate"
+						from="0 18 18"
+						to="360 18 18"
+						dur="0.9s"
+						repeatCount="indefinite"
+					/>
+				</path>
+				<circle fill={Colors.blueHover} cx="36" cy="18" r="1">
+					<animateTransform
+						attributeName="transform"
+						type="rotate"
+						from="0 18 18"
+						to="360 18 18"
+						dur="0.9s"
+						repeatCount="indefinite"
+					/>
+				</circle>
+			</g>
+		</svg>
+	);
+}

--- a/components/GlobalLoader/index.ts
+++ b/components/GlobalLoader/index.ts
@@ -1,0 +1,1 @@
+export { GlobalLoader as default } from './GlobalLoader';

--- a/content/App.tsx
+++ b/content/App.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useEffect } from 'react';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import { RecoilRoot } from 'recoil';
@@ -32,6 +33,12 @@ const queryClient = new QueryClient({
 
 const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
 	const { provider, signer, network, L1DefaultProvider } = Connector.useContainer();
+
+	useEffect(() => {
+		try {
+			document.querySelector('#global-loader')?.remove();
+		} catch (_e) {}
+	}, []);
 
 	return (
 		<>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"@synthetixio/optimism-networks": "^2.74.1",
 		"@synthetixio/providers": "^2.74.1",
 		"@synthetixio/queries": "^2.74.3",
-		"@synthetixio/safe-import": "^1.0.0",
 		"@synthetixio/transaction-notifier": "^2.74.1",
 		"@synthetixio/wei": "^2.74.1",
 		"@tippyjs/react": "^4.1.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,9 +3,11 @@ import '@reach/dialog/styles.css';
 import 'tippy.js/dist/tippy.css';
 
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
 const App = dynamic(() => import('content/App'), {
 	ssr: false,
+	loading: GlobalLoader,
 });
 
 export default App;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,10 +3,9 @@ import '@reach/dialog/styles.css';
 import 'tippy.js/dist/tippy.css';
 
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const App = dynamic(() => safeImport(() => import(/* webpackChunkName: "app" */ 'content/App')), {
-	ssr: true,
+const App = dynamic(() => import('content/App'), {
+	ssr: false,
 });
 
 export default App;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,8 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 import { mediaStyles } from 'styles/media';
+import Colors from 'styles/theme/colors';
+import GlobalLoader from 'components/GlobalLoader';
 
 const PRELOADED_FONTS = [
 	'/fonts/Inter-Regular.woff2',
@@ -44,6 +46,16 @@ export default class MyDocument extends Document {
 			<Html lang="en">
 				<Head>
 					<style type="text/css" dangerouslySetInnerHTML={{ __html: mediaStyles }} />
+					<style
+						type="text/css"
+						dangerouslySetInnerHTML={{
+							__html: `
+								body {
+									background-color: ${Colors.black};
+								}
+							`,
+						}}
+					/>
 					{PRELOADED_FONTS.map((fontPath) => (
 						<link
 							key={fontPath}
@@ -57,6 +69,9 @@ export default class MyDocument extends Document {
 				</Head>
 				<body>
 					<Main />
+					<div id="global-loader">
+						<GlobalLoader />
+					</div>
 					<NextScript />
 				</body>
 			</Html>

--- a/pages/debt.tsx
+++ b/pages/debt.tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const DebtPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "debt" */ 'content/DebtPage')),
-	{ ssr: true }
-);
+const DebtPage = dynamic(() => import('content/DebtPage'), { ssr: false });
 
 export default DebtPage;

--- a/pages/debt.tsx
+++ b/pages/debt.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const DebtPage = dynamic(() => import('content/DebtPage'), { ssr: false });
+const DebtPage = dynamic(() => import('content/DebtPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default DebtPage;

--- a/pages/delegate.tsx
+++ b/pages/delegate.tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const DelegatePage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "delegate" */ 'content/DelegatePage')),
-	{ ssr: true }
-);
+const DelegatePage = dynamic(() => import('content/DelegatePage'), { ssr: false });
 
 export default DelegatePage;

--- a/pages/delegate.tsx
+++ b/pages/delegate.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const DelegatePage = dynamic(() => import('content/DelegatePage'), { ssr: false });
+const DelegatePage = dynamic(() => import('content/DelegatePage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default DelegatePage;

--- a/pages/earn/[[...pool]].tsx
+++ b/pages/earn/[[...pool]].tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const EarnPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "earn" */ 'content/EarnPage')),
-	{ ssr: true }
-);
+const EarnPage = dynamic(() => import('content/EarnPage'), { ssr: false });
 
 export default EarnPage;

--- a/pages/earn/[[...pool]].tsx
+++ b/pages/earn/[[...pool]].tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const EarnPage = dynamic(() => import('content/EarnPage'), { ssr: false });
+const EarnPage = dynamic(() => import('content/EarnPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default EarnPage;

--- a/pages/escrow/[[...action]].tsx
+++ b/pages/escrow/[[...action]].tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const EscrowPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "escrow" */ 'content/EscrowPage')),
-	{ ssr: true }
-);
+const EscrowPage = dynamic(() => import('content/EscrowPage'), { ssr: false });
 
 export default EscrowPage;

--- a/pages/escrow/[[...action]].tsx
+++ b/pages/escrow/[[...action]].tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const EscrowPage = dynamic(() => import('content/EscrowPage'), { ssr: false });
+const EscrowPage = dynamic(() => import('content/EscrowPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default EscrowPage;

--- a/pages/gov/[[...panel]].tsx
+++ b/pages/gov/[[...panel]].tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const GovPage = dynamic(() => import('content/GovPage'), { ssr: false });
+const GovPage = dynamic(() => import('content/GovPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default GovPage;

--- a/pages/gov/[[...panel]].tsx
+++ b/pages/gov/[[...panel]].tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const GovPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "gov" */ 'content/GovPage')),
-	{ ssr: true }
-);
+const GovPage = dynamic(() => import('content/GovPage'), { ssr: false });
 
 export default GovPage;

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const HistoryPage = dynamic(() => import('content/HistoryPage'), { ssr: false });
+const HistoryPage = dynamic(() => import('content/HistoryPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default HistoryPage;

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const HistoryPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "history" */ 'content/HistoryPage')),
-	{ ssr: true }
-);
+const HistoryPage = dynamic(() => import('content/HistoryPage'), { ssr: false });
 
 export default HistoryPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const DashboardPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "dashboard" */ 'content/DashboardPage')),
-	{ ssr: true }
-);
+const DashboardPage = dynamic(() => import('content/DashboardPage'), { ssr: false });
 
 export default DashboardPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const DashboardPage = dynamic(() => import('content/DashboardPage'), { ssr: false });
+const DashboardPage = dynamic(() => import('content/DashboardPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default DashboardPage;

--- a/pages/l2/index.tsx
+++ b/pages/l2/index.tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const L2Page = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "l2" */ 'content/L2Page')),
-	{ ssr: true }
-);
+const L2Page = dynamic(() => import('content/L2Page'), { ssr: false });
 
 export default L2Page;

--- a/pages/l2/index.tsx
+++ b/pages/l2/index.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const L2Page = dynamic(() => import('content/L2Page'), { ssr: false });
+const L2Page = dynamic(() => import('content/L2Page'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default L2Page;

--- a/pages/l2/migrate.tsx
+++ b/pages/l2/migrate.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const L2MigratePage = dynamic(() => import('content/L2MigratePage'), { ssr: false });
+const L2MigratePage = dynamic(() => import('content/L2MigratePage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default L2MigratePage;

--- a/pages/l2/migrate.tsx
+++ b/pages/l2/migrate.tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const L2MigratePage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "l2-migrate" */ 'content/L2MigratePage')),
-	{ ssr: true }
-);
+const L2MigratePage = dynamic(() => import('content/L2MigratePage'), { ssr: false });
 
 export default L2MigratePage;

--- a/pages/loans/[[...action]].tsx
+++ b/pages/loans/[[...action]].tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const LoansPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "loans" */ 'content/LoansPage')),
-	{ ssr: true }
-);
+const LoansPage = dynamic(() => import('content/LoansPage'), { ssr: false });
 
 export default LoansPage;

--- a/pages/loans/[[...action]].tsx
+++ b/pages/loans/[[...action]].tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const LoansPage = dynamic(() => import('content/LoansPage'), { ssr: false });
+const LoansPage = dynamic(() => import('content/LoansPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default LoansPage;

--- a/pages/merge-accounts/[[...action]].tsx
+++ b/pages/merge-accounts/[[...action]].tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const MergeAccountsPage = dynamic(() => import('content/MergeAccountsPage'), { ssr: false });
+const MergeAccountsPage = dynamic(() => import('content/MergeAccountsPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default MergeAccountsPage;

--- a/pages/merge-accounts/[[...action]].tsx
+++ b/pages/merge-accounts/[[...action]].tsx
@@ -1,10 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const MergeAccountsPage = dynamic(
-	() =>
-		safeImport(() => import(/* webpackChunkName: "merge-accounts" */ 'content/MergeAccountsPage')),
-	{ ssr: true }
-);
+const MergeAccountsPage = dynamic(() => import('content/MergeAccountsPage'), { ssr: false });
 
 export default MergeAccountsPage;

--- a/pages/pools/[[...pool]].tsx
+++ b/pages/pools/[[...pool]].tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const PoolsPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "pools" */ 'content/PoolsPage')),
-	{ ssr: true }
-);
+const PoolsPage = dynamic(() => import('content/PoolsPage'), { ssr: false });
 
 export default PoolsPage;

--- a/pages/pools/[[...pool]].tsx
+++ b/pages/pools/[[...pool]].tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const PoolsPage = dynamic(() => import('content/PoolsPage'), { ssr: false });
+const PoolsPage = dynamic(() => import('content/PoolsPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default PoolsPage;

--- a/pages/staking/[[...action]].tsx
+++ b/pages/staking/[[...action]].tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const StakingPage = dynamic(() => import('content/StakingPage'), { ssr: false });
+const StakingPage = dynamic(() => import('content/StakingPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default StakingPage;

--- a/pages/staking/[[...action]].tsx
+++ b/pages/staking/[[...action]].tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const StakingPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "staking" */ 'content/StakingPage')),
-	{ ssr: true }
-);
+const StakingPage = dynamic(() => import('content/StakingPage'), { ssr: false });
 
 export default StakingPage;

--- a/pages/synths.tsx
+++ b/pages/synths.tsx
@@ -1,9 +1,5 @@
 import dynamic from 'next/dynamic';
-import { safeImport } from '@synthetixio/safe-import';
 
-const SynthsPage = dynamic(
-	() => safeImport(() => import(/* webpackChunkName: "synths" */ 'content/SynthsPage')),
-	{ ssr: true }
-);
+const SynthsPage = dynamic(() => import('content/SynthsPage'), { ssr: false });
 
 export default SynthsPage;

--- a/pages/synths.tsx
+++ b/pages/synths.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import GlobalLoader from 'components/GlobalLoader';
 
-const SynthsPage = dynamic(() => import('content/SynthsPage'), { ssr: false });
+const SynthsPage = dynamic(() => import('content/SynthsPage'), {
+	ssr: false,
+	loading: GlobalLoader,
+});
 
 export default SynthsPage;

--- a/typings/missing-types.d.ts
+++ b/typings/missing-types.d.ts
@@ -4,4 +4,3 @@ declare module '@ensdomains/ensjs';
 declare module '@eth-optimism/watcher';
 declare module 'remarkable/linkify';
 declare module 'remarkable-external-link';
-declare module '@synthetixio/safe-import';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,15 +3876,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@synthetixio/safe-import@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@synthetixio/safe-import@npm:1.0.0"
-  dependencies:
-    react: ^17.0.2
-  checksum: 97f14cb6d291ec24c1b4551440d12b7765aba6ca306a94113ed30859285f5045c4b70ff468edcf34ec2e0515a9d60a48646166561da9ff5cc8405e451fab9ad5
-  languageName: node
-  linkType: hard
-
 "@synthetixio/synpress@npm:^1.1.1":
   version: 1.2.0
   resolution: "@synthetixio/synpress@npm:1.2.0"
@@ -21692,7 +21683,6 @@ jschardet@latest:
     "@synthetixio/optimism-networks": ^2.74.1
     "@synthetixio/providers": ^2.74.1
     "@synthetixio/queries": ^2.74.3
-    "@synthetixio/safe-import": ^1.0.0
     "@synthetixio/synpress": ^1.1.1
     "@synthetixio/transaction-notifier": ^2.74.1
     "@synthetixio/wei": ^2.74.1


### PR DESCRIPTION
1. Disable server side rendering
2. Update body background to match app
3. Create GlobalLoader (cannot import `svg` as Next is "too smart" and prohibits importing "images" for pre-generated html, not understanding that it is actually imported as react component).
4. Add `loading` state for dynamic imports
5. `safe-import` is unfortunately removed (again because Next is "too smart" and does replace internal importing functionality preventing it throwing exceptions)

We still have some things to do about that initial styling on dashboard page

Loader freezes for me because JS processing eats up all my CPU 🤦 
![loader-state](https://user-images.githubusercontent.com/28145325/178658901-27ef0ee5-04b2-4910-81e0-9961549699ca.gif)
