### PR TITLE
add hedge now button post mint

### DIFF
--- a/sections/shared/Layout/SideNav/Desktop/DesktopSubMenu.tsx
+++ b/sections/shared/Layout/SideNav/Desktop/DesktopSubMenu.tsx
@@ -1,4 +1,4 @@
-import { DESKTOP_SIDE_NAV_WIDTH, zIndex } from 'constants/ui';
+import { DESKTOP_SIDE_NAV_WIDTH } from 'constants/ui';
 import useIsMounted from 'hooks/isMounted';
 import { FC, ReactNode } from 'react';
 import { createPortal } from 'react-dom';

--- a/sections/staking/components/TxSent/ActionCompleted.tsx
+++ b/sections/staking/components/TxSent/ActionCompleted.tsx
@@ -133,6 +133,7 @@ const ActionCompleted: React.FC<ActionCompletedProps> = ({
 							</LeftButton>
 						</ExternalLink>
 					) : null}
+
 					<RightButton
 						onClick={() => {
 							resetTransaction();
@@ -142,6 +143,9 @@ const ActionCompleted: React.FC<ActionCompletedProps> = ({
 					>
 						{t('staking.actions.mint.completed-default.dismiss')}
 					</RightButton>
+					<HedgeButton onClick={() => push(ROUTES.Debt.Home)}>
+						{t('staking.actions.mint.completed-default.hedge')}
+					</HedgeButton>
 				</ButtonWrap>
 			</Container>
 		);
@@ -228,6 +232,10 @@ const AprValue = styled.div`
 `;
 
 const BaseButton = styled.div`
+	@media (max-width: 768px) {
+		min-width: 60px;
+		width: 120px;
+	}
 	width: 175px;
 	height: 50px;
 	padding-top: 16px;
@@ -249,6 +257,13 @@ const LeftButton = styled(BaseButton)`
 `;
 
 const RightButton = styled(BaseButton)`
+	background-color: ${(props) => props.theme.colors.black};
+	color: ${(props) => props.theme.colors.white};
+	border: 1px solid ${(props) => props.theme.colors.gray};
+	text-transform: uppercase;
+`;
+
+const HedgeButton = styled(BaseButton)`
 	${boxShadowBlue}
 	background-color: ${(props) => props.theme.colors.grayBlue};
 	color: ${(props) => props.theme.colors.blue};

--- a/translations/en.json
+++ b/translations/en.json
@@ -270,14 +270,16 @@
 					"est-apr": "Est. APR",
 					"subtext": "There are various Liquidity Providing incentives interacting with different DeFi products for you to choose from",
 					"dismiss": "DISMISS",
-					"see-more": "SEE MORE"
+					"see-more": "SEE MORE",
+					"hedge": "HEDGE NOW"
 				},
 				"completed-default": {
 					"title": "Minting complete!",
 					"staked": "Staked",
 					"minted": "Minted",
 					"dismiss": "Dismiss",
-					"verify": "Verify Tx"
+					"verify": "Verify Tx",
+					"hedge": "HEDGE NOW"
 				}
 			},
 			"burn": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -271,7 +271,7 @@
 					"subtext": "There are various Liquidity Providing incentives interacting with different DeFi products for you to choose from",
 					"dismiss": "DISMISS",
 					"see-more": "SEE MORE",
-					"hedge": "HEDGE NOW"
+					"hedge": "HEDGE DEBT"
 				},
 				"completed-default": {
 					"title": "Minting complete!",
@@ -279,7 +279,7 @@
 					"minted": "Minted",
 					"dismiss": "Dismiss",
 					"verify": "Verify Tx",
-					"hedge": "HEDGE NOW"
+					"hedge": "HEDGE DEBT"
 				}
 			},
 			"burn": {


### PR DESCRIPTION
This PR adds a button on mint success that sends users to the debt route.
<img width="803" alt="Screen Shot 2022-07-20 at 8 52 49 pm" src="https://user-images.githubusercontent.com/52280438/179965270-50d27da6-6946-4df6-b720-8bd444cf1112.png">
