### PR TITLE
We don't need graphql-request

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
 		"date-fns": "^2.15.0",
 		"ethers": "^5.5.3",
 		"graphql": "^15.5.0",
-		"graphql-request": "^3.4.0",
 		"i18next": "^19.7.0",
 		"lodash": "^4.17.20",
 		"next": "^12.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20918,7 +20918,6 @@ jschardet@latest:
     file-loader: ^6.2.0
     graph-results-pager: ^1.0.3
     graphql: ^15.5.0
-    graphql-request: ^3.4.0
     husky: ^8.0.1
     i18next: ^19.7.0
     jest: ^28.1.2


### PR DESCRIPTION
GraphQL requests are simple POST fetches, there is no need in using extra layer of abstraction.
We are using in in one place only so a small one to replace

Still working as expected
![Screen Shot 2022-08-01 at 14 22 10](https://user-images.githubusercontent.com/28145325/182085687-f22d61c8-a9af-41f6-897b-32964fbcc6c9.png)

With network error simulated:
![image](https://user-images.githubusercontent.com/28145325/182085895-a557f982-423a-4c90-8806-b1d813ce13e8.png)

Trying to replicate that new Error throw (not breaking UI either):
![image](https://user-images.githubusercontent.com/28145325/182086029-b5ccab4f-91f0-4390-abed-3a3720c40d57.png)
