### PR TITLE
firefox bug fix

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -104,3 +104,8 @@ input::-webkit-inner-spin-button {
 	--onboard-connect-sidebar-progress-background: #343a4a;
 	--onboard-connect-sidebar-progress-color: #00d1ff;
 }
+
+/* Bug fix for react datepicker on Firefox (hides dropdown icon) */
+.react-datepicker__input-container .dropdown-icon {
+	display: none;
+}


### PR DESCRIPTION
Hides the dropdown icon
![firefox](https://user-images.githubusercontent.com/52280438/182495877-91eea957-07c4-41fa-8be4-7f3048623f0f.png)
 