### PR TITLE
Fix historical debt data hook.

### DIFF
--- a/utils/ts-helpers.ts
+++ b/utils/ts-helpers.ts
@@ -6,3 +6,6 @@ export function isObjectOrErrorWithMessage(x: unknown): x is { message: string }
 export function notNill<Value>(value: Value | null | undefined): value is Value {
 	return value !== null && value !== undefined;
 }
+
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;


### PR DESCRIPTION
- Previously it falsely assumed that number of debtSnapshots and mints/burns would match, this is NOT true
- Also did some small refactor, removed reliance on lodash and added comment

Wallet that reported the issue (private):
Before:
<img width="977" alt="Screen Shot 2022-08-10 at 1 52 07 pm" src="https://user-images.githubusercontent.com/5688912/183899132-7ec5de87-a06a-49e4-ba9c-5bef81b8526a.png">
After:
<img width="838" alt="Screen Shot 2022-08-10 at 1 51 12 pm" src="https://user-images.githubusercontent.com/5688912/183899137-9bd38063-c32e-4b2d-a864-e70b5a861ae8.png">
s