### PR TITLE
Connecting to unsupported network

### DIFF
--- a/components/ApproveModal/ApproveModal.tsx
+++ b/components/ApproveModal/ApproveModal.tsx
@@ -55,8 +55,8 @@ const ApproveModal: FC<ApproveModalProps & SynthetixJsAndSignerProps> = ({
 	const [gasPrice, setGasPrice] = useState<GasPrice | undefined>(undefined);
 	const [isApproving, setIsApproving] = useState<boolean>(false);
 	const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
-	const tokenContract = getContractByName(synthetixjs!, tokenContractName, signer);
-	const contractToApprove = getContractByName(synthetixjs!, contractToApproveName, signer);
+	const tokenContract = getContractByName(synthetixjs, tokenContractName, signer);
+	const contractToApprove = getContractByName(synthetixjs, contractToApproveName, signer);
 	const allowance = synthetixjs?.utils.parseEther(TokenAllowanceLimit.toString());
 
 	const txn = useContractTxn(

--- a/components/ConnectOrSwitchNetwork.tsx
+++ b/components/ConnectOrSwitchNetwork.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import styled from 'styled-components';
+import Connector from '../containers/Connector';
+import Button from 'components/Button';
+import { useTranslation } from 'react-i18next';
+import { NetworkIdByName } from '@synthetixio/contracts-interface';
+
+const ConnectOrSwitchNetwork: React.FC = () => {
+	const { connectWallet, isWalletConnected, switchNetwork, walletConnectedToUnsupportedNetwork } =
+		Connector.useContainer();
+	const { t } = useTranslation();
+
+	if (walletConnectedToUnsupportedNetwork) {
+		return (
+			<>
+				<p>{t('common.wallet.switch-to-supported')}</p>
+				<ButtonContainer>
+					<StyledCTA
+						variant="primary"
+						size="lg"
+						onClick={() => {
+							switchNetwork(NetworkIdByName['mainnet']);
+						}}
+					>
+						{t('modals.wallet.network.ethereum')}
+					</StyledCTA>
+					<StyledCTA
+						variant="primary"
+						size="lg"
+						onClick={() => {
+							switchNetwork(NetworkIdByName['mainnet-ovm']);
+						}}
+					>
+						{t('modals.wallet.network.optimism')}
+					</StyledCTA>
+				</ButtonContainer>
+			</>
+		);
+	}
+	if (!isWalletConnected) {
+		return (
+			<StyledCTA variant="primary" size="lg" onClick={connectWallet}>
+				{t('common.wallet.connect-wallet')}
+			</StyledCTA>
+		);
+	}
+	return null;
+};
+
+const ButtonContainer = styled.div`
+	display: flex;
+`;
+
+const StyledCTA = styled(Button)`
+	font-size: 14px;
+	font-family: ${(props) => props.theme.fonts.condensedMedium};
+	box-shadow: 0px 0px 10px rgba(0, 209, 255, 0.9);
+	border-radius: 4px;
+	width: 100%;
+	text-transform: uppercase;
+	margin: 0 10px;
+
+	&:disabled {
+		box-shadow: none;
+	}
+`;
+
+export default ConnectOrSwitchNetwork;

--- a/components/ConnectOrSwitchNetwork.tsx
+++ b/components/ConnectOrSwitchNetwork.tsx
@@ -13,7 +13,7 @@ const ConnectOrSwitchNetwork: React.FC = () => {
 	if (walletConnectedToUnsupportedNetwork) {
 		return (
 			<>
-				<p>{t('common.wallet.switch-to-supported')}</p>
+				<P>{t('common.wallet.switch-to-supported')}</P>
 				<ButtonContainer>
 					<StyledCTA
 						variant="primary"
@@ -39,24 +39,34 @@ const ConnectOrSwitchNetwork: React.FC = () => {
 	}
 	if (!isWalletConnected) {
 		return (
-			<StyledCTA variant="primary" size="lg" onClick={connectWallet}>
-				{t('common.wallet.connect-wallet')}
-			</StyledCTA>
+			<ButtonContainer>
+				<StyledCTA variant="primary" size="lg" onClick={connectWallet}>
+					{t('common.wallet.connect-wallet')}
+				</StyledCTA>
+			</ButtonContainer>
 		);
 	}
 	return null;
 };
 
+const P = styled.p`
+	text-align: center;
+	color: white;
+	text-transform: uppercase;
+	font-family: ${(props) => props.theme.fonts.condensedMedium};
+	font-size: 14px;
+`;
 const ButtonContainer = styled.div`
 	display: flex;
+	justify-content: center;
 `;
-
 const StyledCTA = styled(Button)`
 	font-size: 14px;
 	font-family: ${(props) => props.theme.fonts.condensedMedium};
 	box-shadow: 0px 0px 10px rgba(0, 209, 255, 0.9);
 	border-radius: 4px;
 	width: 100%;
+	max-width: 200px;
 	text-transform: uppercase;
 	margin: 0 10px;
 

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -5,13 +5,13 @@ import { Synths } from './currency';
 
 export const QUERY_KEYS = {
 	Debt: {
-		WalletDebtData: (walletAddress: string, networkId: NetworkId) => [
+		WalletDebtData: (walletAddress: string, networkId: number) => [
 			'debt',
 			'walletDebtData',
 			walletAddress,
 			networkId,
 		],
-		DebtSnapshot: (walletAddress: string, networkId: NetworkId) => [
+		DebtSnapshot: (walletAddress: string, networkId: number) => [
 			'debt',
 			'debtSnapshot',
 			walletAddress,
@@ -19,7 +19,7 @@ export const QUERY_KEYS = {
 		],
 	},
 	Liquidations: {
-		LiquidationsData: (walletAddress: string, networkId: NetworkId) => [
+		LiquidationsData: (walletAddress: string, networkId: number) => [
 			'liquidations',
 			'liquidationsData',
 			walletAddress,
@@ -29,31 +29,31 @@ export const QUERY_KEYS = {
 	Staking: {
 		MinimumStakeTime: ['minimumStakeTime'],
 		FeePoolData: (period: string) => ['staking', 'feePoolData', period],
-		FeeClaimHistory: (walletAddress: string, networkId: NetworkId) => [
+		FeeClaimHistory: (walletAddress: string, networkId: number) => [
 			'staking',
 			'feelClaimHistory',
 			walletAddress,
 			networkId,
 		],
-		ClaimableRewards: (walletAddress: string, networkId: NetworkId) => [
+		ClaimableRewards: (walletAddress: string, networkId: number) => [
 			'staking',
 			'claimableRewards',
 			walletAddress,
 			networkId,
 		],
-		Issued: (walletAddress: string, networkId: NetworkId) => [
+		Issued: (walletAddress: string, networkId: number) => [
 			'staking',
 			'issued',
 			walletAddress,
 			networkId,
 		],
-		Burned: (walletAddress: string, networkId: NetworkId) => [
+		Burned: (walletAddress: string, networkId: number) => [
 			'staking',
 			'burned',
 			walletAddress,
 			networkId,
 		],
-		SNXLockedValue: (networkId: NetworkId) => ['staking', 'lockedValue', networkId],
+		SNXLockedValue: (networkId: number) => ['staking', 'lockedValue', networkId],
 	},
 	Network: {
 		SNXTotalSupply: ['network', 'snxTotalSupply'],
@@ -63,19 +63,19 @@ export const QUERY_KEYS = {
 		WalletTrades: (walletAddress: string) => ['trades', 'walletTrades', walletAddress],
 	},
 	Depot: {
-		UserActions: (walletAddress: string, networkId: NetworkId) => [
+		UserActions: (walletAddress: string, networkId: number) => [
 			'depot',
 			'userActions',
 			walletAddress,
 			networkId,
 		],
-		ClearDeposits: (walletAddress: string, networkId: NetworkId) => [
+		ClearDeposits: (walletAddress: string, networkId: number) => [
 			'depot',
 			'clearDeposits',
 			walletAddress,
 			networkId,
 		],
-		Exchanges: (walletAddress: string, networkId: NetworkId) => [
+		Exchanges: (walletAddress: string, networkId: number) => [
 			'depot',
 			'exchanges',
 			walletAddress,
@@ -83,13 +83,13 @@ export const QUERY_KEYS = {
 		],
 	},
 	Escrow: {
-		StakingRewards: (walletAddress: string, networkId: NetworkId) => [
+		StakingRewards: (walletAddress: string, networkId: number) => [
 			'escrow',
 			'stakingRewards',
 			walletAddress,
 			networkId,
 		],
-		TokenSale: (walletAddress: string, networkId: NetworkId) => [
+		TokenSale: (walletAddress: string, networkId: number) => [
 			'escrow',
 			'tokenSale',
 			walletAddress,
@@ -97,43 +97,43 @@ export const QUERY_KEYS = {
 		],
 	},
 	LiquidityPools: {
-		iETH: (walletAddress: string, networkId: NetworkId) => [
+		iETH: (walletAddress: string, networkId: number) => [
 			'liquidityPools',
 			'iETH',
 			walletAddress,
 			networkId,
 		],
-		iBTC: (walletAddress: string, networkId: NetworkId) => [
+		iBTC: (walletAddress: string, networkId: number) => [
 			'liquidityPools',
 			'iBTC',
 			walletAddress,
 			networkId,
 		],
-		Balancer: (walletAddress: string, synth: Synths, networkId: NetworkId) => [
+		Balancer: (walletAddress: string, synth: Synths, networkId: number) => [
 			'liquidityPools',
 			synth,
 			walletAddress,
 			networkId,
 		],
-		sUSD: (walletAddress: string, networkId: NetworkId) => [
+		sUSD: (walletAddress: string, networkId: number) => [
 			'liquidityPools',
 			'curve',
 			walletAddress,
 			networkId,
 		],
-		sEUR: (walletAddress: string, networkId: NetworkId) => [
+		sEUR: (walletAddress: string, networkId: number) => [
 			'liquidityPools',
 			'sEUR',
 			walletAddress,
 			networkId,
 		],
-		DHTsUSD: (walletAddress: string, networkId: NetworkId) => [
+		DHTsUSD: (walletAddress: string, networkId: number) => [
 			'liquidityPools',
 			'DHT-sUSD',
 			walletAddress,
 			networkId,
 		],
-		yearnSNX: (walletAddress: string, networkId: NetworkId) => [
+		yearnSNX: (walletAddress: string, networkId: number) => [
 			'liquidityPools',
 			'yearn-SNX',
 			walletAddress,
@@ -141,13 +141,13 @@ export const QUERY_KEYS = {
 		],
 	},
 	Delegate: {
-		AuthoriserWallets: (walletAddress: string, networkId: NetworkId) => [
+		AuthoriserWallets: (walletAddress: string, networkId: number) => [
 			'delegate',
 			'authoriserWallets',
 			walletAddress,
 			networkId,
 		],
-		DelegateWallets: (walletAddress: string, networkId: NetworkId) => [
+		DelegateWallets: (walletAddress: string, networkId: number) => [
 			'delegate',
 			'delegateWallets',
 			walletAddress,
@@ -155,13 +155,13 @@ export const QUERY_KEYS = {
 		],
 	},
 	ShortRewards: {
-		sBTC: (walletAddress: string, networkId: NetworkId) => [
+		sBTC: (walletAddress: string, networkId: number) => [
 			'shortRewards',
 			'sBTC',
 			walletAddress,
 			networkId,
 		],
-		sETH: (walletAddress: string, networkId: NetworkId) => [
+		sETH: (walletAddress: string, networkId: number) => [
 			'shortRewards',
 			'sETH',
 			walletAddress,
@@ -169,13 +169,13 @@ export const QUERY_KEYS = {
 		],
 	},
 	Deposits: {
-		Data: (walletAddress: string, networkId: NetworkId) => [
+		Data: (walletAddress: string, networkId: number) => [
 			'deposits',
 			'depositsData',
 			walletAddress,
 			networkId,
 		],
-		IsActive: (walletAddress: string, networkId: NetworkId) => [
+		IsActive: (walletAddress: string, networkId: number) => [
 			'deposits',
 			'depositsIsActive',
 			walletAddress,
@@ -183,13 +183,13 @@ export const QUERY_KEYS = {
 		],
 	},
 	Withdrawals: {
-		Data: (walletAddress: string, networkId: NetworkId) => [
+		Data: (walletAddress: string, networkId: number) => [
 			'withdrawals',
 			'withdrawalsData',
 			walletAddress,
 			networkId,
 		],
-		IsActive: (walletAddress: string, networkId: NetworkId) => [
+		IsActive: (walletAddress: string, networkId: number) => [
 			'withdrawals',
 			'withdrawalsIsActive',
 			walletAddress,
@@ -197,7 +197,7 @@ export const QUERY_KEYS = {
 		],
 	},
 	Swap: {
-		quote1Inch: (walletAddress: string, networkId: NetworkId, amount: WeiSource) => [
+		quote1Inch: (walletAddress: string, networkId: number, amount: WeiSource) => [
 			'quote',
 			'1inch',
 			walletAddress,
@@ -206,13 +206,13 @@ export const QUERY_KEYS = {
 		],
 		swap1Inch: (
 			walletAddress: string,
-			networkId: NetworkId,
+			networkId: number,
 			amount: WeiSource,
 			fromAddress: string
 		) => ['swap', '1inch', walletAddress, networkId, amount, fromAddress],
 	},
 	Gov: {
-		DebtOwnership: (walletAddress: string, networkId: NetworkId, block?: number | null) => [
+		DebtOwnership: (walletAddress: string, networkId: number, block?: number | null) => [
 			'gov',
 			'debtOwnership',
 			walletAddress,
@@ -220,14 +220,14 @@ export const QUERY_KEYS = {
 			block,
 		],
 		SnapshotSpace: (spaceKey: SPACE_KEY) => ['gov', 'snapshotSpace', spaceKey],
-		Proposals: (spaceKey: SPACE_KEY, walletAddress: string, networkId: NetworkId) => [
+		Proposals: (spaceKey: SPACE_KEY, walletAddress: string, networkId: number) => [
 			'gov',
 			'proposals',
 			spaceKey,
 			walletAddress,
 			networkId,
 		],
-		ActiveProposals: (walletAddress: string, networkId: NetworkId) => [
+		ActiveProposals: (walletAddress: string, networkId: number) => [
 			'gov',
 			'activeProposals',
 			walletAddress,

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -1,4 +1,3 @@
-import { NetworkId } from '@synthetixio/contracts-interface';
 import { WeiSource } from '@synthetixio/wei';
 import { SPACE_KEY } from 'constants/snapshot';
 import { Synths } from './currency';

--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -275,6 +275,9 @@ const useConnector = () => {
 		}
 	}, [onboard, updateState]);
 
+	const switchNetwork = async (id: NetworkId) => {
+		return onboard?.setChain({ chainId: getChainIdHex(id) });
+	};
 	return {
 		isAppReady,
 		network,
@@ -302,6 +305,7 @@ const useConnector = () => {
 		ensAvatar,
 		setWatchedWallet,
 		stopWatching,
+		switchNetwork,
 	};
 };
 

--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -252,7 +252,7 @@ const useConnector = () => {
 
 			return currencyKey === 'ETH'
 				? ETH_ADDRESS
-				: synthetixjs!.contracts[synthToContractName(currencyKey!)].address;
+				: synthetixjs.contracts[synthToContractName(currencyKey!)].address;
 		},
 		[synthetixjs]
 	);

--- a/containers/Connector/reducer.ts
+++ b/containers/Connector/reducer.ts
@@ -48,7 +48,7 @@ export type ConnectionUpdate = {
 	signer: ethers.Signer | null;
 	walletWatched: null;
 	walletType: string | null;
-	synthetixjs: SynthetixJS;
+	synthetixjs: SynthetixJS | null;
 	provider: SynthetixProvider;
 	ensName: string | null;
 	ensAvatar: string | null;

--- a/content/App.tsx
+++ b/content/App.tsx
@@ -21,6 +21,7 @@ import SystemStatus from 'sections/shared/SystemStatus';
 import '../i18n';
 import Connector from 'containers/Connector';
 import Script from 'next/script';
+import { isSupportedNetworkId } from '../utils/network';
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -32,23 +33,23 @@ const queryClient = new QueryClient({
 });
 
 const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
-	const { provider, signer, network, L1DefaultProvider } = Connector.useContainer();
+	const { provider, signer, network, L1DefaultProvider, synthetixjs } = Connector.useContainer();
 
 	useEffect(() => {
 		try {
 			document.querySelector('#global-loader')?.remove();
 		} catch (_e) {}
 	}, []);
-
+	const networkId = String(network?.id);
 	return (
 		<>
 			<SynthetixQueryContextProvider
 				value={
-					provider && network?.id
+					provider && isSupportedNetworkId(networkId) && synthetixjs
 						? createQueryContext({
 								provider: provider,
 								signer: signer || undefined,
-								networkId: network.id,
+								networkId,
 						  })
 						: createQueryContext({
 								networkId: 1,

--- a/content/BridgePage.tsx
+++ b/content/BridgePage.tsx
@@ -7,7 +7,8 @@ import { useTranslation } from 'react-i18next';
 import media from 'styles/media';
 
 const BridgePage = () => {
-	const { connectWallet, isWalletConnected } = Connector.useContainer();
+	const { connectWallet, walletConnectedToUnsupportedNetwork, isWalletConnected } =
+		Connector.useContainer();
 
 	const { t } = useTranslation();
 	return (
@@ -19,7 +20,7 @@ const BridgePage = () => {
 				<Headline>{t('bridge.headline')}</Headline>
 			</HeadlineContainer>
 
-			{isWalletConnected ? (
+			{Boolean(walletConnectedToUnsupportedNetwork || isWalletConnected) ? (
 				<>
 					<SocketBridge />
 				</>

--- a/content/PoolsPage.tsx
+++ b/content/PoolsPage.tsx
@@ -15,6 +15,7 @@ import synthetix, { NetworkIdByName } from '@synthetixio/contracts-interface';
 import Connector from 'containers/Connector';
 import Button from 'components/Button';
 import { switchToL2 } from '@synthetixio/optimism-networks';
+import ConnectOrSwitchNetwork from '../components/ConnectOrSwitchNetwork';
 
 function Pool() {
 	const [LPBalance, setLPBalance] = useState(BigNumber.from(0));
@@ -144,15 +145,12 @@ function Pool() {
 
 const PoolWrapper = () => {
 	const { t } = useTranslation();
-	const { connectWallet, isL2, isWalletConnected, walletAddress } = Connector.useContainer();
+	const { isL2, isWalletConnected, walletAddress } = Connector.useContainer();
 
 	if (!isWalletConnected || !walletAddress) {
 		return (
 			<WrapperContainer>
-				<h3>{t('pool.connect-wallet-text')}</h3>
-				<Button variant="primary" onClick={connectWallet}>
-					{t('common.wallet.connect-wallet')}
-				</Button>
+				<ConnectOrSwitchNetwork />
 			</WrapperContainer>
 		);
 	}

--- a/contracts/ethToken.ts
+++ b/contracts/ethToken.ts
@@ -1,6 +1,7 @@
 import { Network } from 'store/wallet';
 import { ethers } from 'ethers';
 import { DEFAULT_NETWORK_ID } from 'constants/defaults';
+import { isSupportedNetworkId } from '../utils/network';
 
 export const getETHToken = (network?: Network | null) => {
 	return {
@@ -9,7 +10,7 @@ export const getETHToken = (network?: Network | null) => {
 		decimals: 18,
 		logoURI: '',
 		name: 'Ethereum',
-		chainId: network?.id ?? DEFAULT_NETWORK_ID,
+		chainId: network?.id && isSupportedNetworkId(network?.id) ? network.id : DEFAULT_NETWORK_ID,
 		tags: [],
 	};
 };

--- a/queries/liquidityPools/useBalancerPoolQuery.ts
+++ b/queries/liquidityPools/useBalancerPoolQuery.ts
@@ -33,9 +33,11 @@ const useBalancerPoolQuery = (
 	return useQuery<LiquidityPoolData>(
 		QUERY_KEYS.LiquidityPools.Balancer(walletAddress ?? '', synth, network?.id!),
 		async () => {
+			if (!synthetixjs) throw Error('Expected synthetixjs do be defined');
+
 			const {
 				contracts: { [rewardsContractName]: StakingRewardsContract },
-			} = synthetixjs!;
+			} = synthetixjs;
 
 			const BPTokenPrice = getBalancerPool(balancerPoolTokenContract.address);
 
@@ -94,7 +96,7 @@ const useBalancerPoolQuery = (
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected && isMainnet,
+			enabled: isAppReady && isWalletConnected && isMainnet && synthetixjs,
 			...options,
 		}
 	);

--- a/queries/liquidityPools/useBalancerPoolQuery.ts
+++ b/queries/liquidityPools/useBalancerPoolQuery.ts
@@ -96,7 +96,7 @@ const useBalancerPoolQuery = (
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected && isMainnet && synthetixjs,
+			enabled: Boolean(isAppReady && isWalletConnected && isMainnet && synthetixjs),
 			...options,
 		}
 	);

--- a/queries/liquidityPools/useYearnSNXVaultQuery.ts
+++ b/queries/liquidityPools/useYearnSNXVaultQuery.ts
@@ -31,13 +31,11 @@ const useYearnSNXVaultQuery = (options?: UseQueryOptions<YearnVaultData>) => {
 	return useQuery<YearnVaultData>(
 		QUERY_KEYS.LiquidityPools.yearnSNX(walletAddress ?? '', network?.id!),
 		async () => {
-			const {
-				contracts: { Synthetix },
-			} = synthetixjs!;
+			if (!synthetixjs) throw Error('Expected synthetixjs do be defined');
+			const Synthetix = synthetixjs?.contracts.Synthetix;
 
 			const YearnSNXVault = new ethers.Contract(
 				yearnSNXVault.address,
-				// @ts-ignore
 				yearnSNXVault.abi,
 				provider as ethers.providers.Provider
 			);
@@ -82,7 +80,7 @@ const useYearnSNXVaultQuery = (options?: UseQueryOptions<YearnVaultData>) => {
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected && isMainnet,
+			enabled: isAppReady && isWalletConnected && isMainnet && synthetixjs,
 			...options,
 		}
 	);

--- a/queries/liquidityPools/useYearnSNXVaultQuery.ts
+++ b/queries/liquidityPools/useYearnSNXVaultQuery.ts
@@ -80,7 +80,7 @@ const useYearnSNXVaultQuery = (options?: UseQueryOptions<YearnVaultData>) => {
 			};
 		},
 		{
-			enabled: isAppReady && isWalletConnected && isMainnet && synthetixjs,
+			enabled: Boolean(isAppReady && isWalletConnected && isMainnet && synthetixjs),
 			...options,
 		}
 	);

--- a/sections/debt/components/DebtChart/DebtChart.tsx
+++ b/sections/debt/components/DebtChart/DebtChart.tsx
@@ -13,7 +13,6 @@ import {
 	ReferenceLine,
 } from 'recharts';
 
-import Button from 'components/Button';
 import Connector from 'containers/Connector';
 import { FlexDivColCentered } from 'styles/common';
 import { formatCurrency } from 'utils/formatters/number';
@@ -21,6 +20,7 @@ import { Synths } from 'constants/currency';
 
 import SpinnerIcon from 'assets/svg/app/loader.svg';
 import Wei from '@synthetixio/wei';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 const LEGEND_LABELS = {
 	actualDebt: 'debt.actions.track.chart.tooltip.actualDebt',
@@ -72,16 +72,10 @@ type Data = {
 const DebtChart = ({ data, isLoading }: { data: Data[]; isLoading: boolean }) => {
 	const { t } = useTranslation();
 	const { colors, fonts } = useTheme();
-	const { connectWallet, isWalletConnected } = Connector.useContainer();
+	const { isWalletConnected } = Connector.useContainer();
 
 	if (!isWalletConnected) {
-		return (
-			<DefaultContainer>
-				<Button variant="primary" onClick={connectWallet}>
-					{t('common.wallet.connect-wallet')}
-				</Button>
-			</DefaultContainer>
-		);
+		return <ConnectOrSwitchNetwork />;
 	}
 
 	if (isLoading) {

--- a/sections/debt/components/ManageTab/index.tsx
+++ b/sections/debt/components/ManageTab/index.tsx
@@ -1,8 +1,7 @@
-import Button from 'components/Button';
 import Connector from 'containers/Connector';
-import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { FlexDivColCentered } from 'styles/common';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 import HedgeTapMainnet from './HedgeTabMainnet';
 import HedgeTabOptimism from './HedgeTabOptimism';
 
@@ -12,7 +11,7 @@ const ManageTab = () => {
 	if (!walletAddress || !isWalletConnected) {
 		return (
 			<ManageContainer>
-				<ConnectWallet />
+				<ConnectOrSwitchNetwork />
 			</ManageContainer>
 		);
 	}
@@ -31,23 +30,3 @@ const ManageContainer = styled(FlexDivColCentered)`
 `;
 
 export default ManageTab;
-
-const ConnectWallet = () => {
-	const { t } = useTranslation();
-	const { connectWallet } = Connector.useContainer();
-	return (
-		<WrapperContainer>
-			<Button variant="primary" onClick={connectWallet}>
-				{t('common.wallet.connect-wallet')}
-			</Button>
-		</WrapperContainer>
-	);
-};
-
-const WrapperContainer = styled.div`
-	margin-top: 200px;
-	display: flex;
-	height: 100%;
-	align-items: center;
-	flex-direction: column;
-`;

--- a/sections/debt/components/PortfolioTable/PortfolioTable.tsx
+++ b/sections/debt/components/PortfolioTable/PortfolioTable.tsx
@@ -4,13 +4,7 @@ import styled from 'styled-components';
 import { useTranslation, Trans } from 'react-i18next';
 import Wei, { wei } from '@synthetixio/wei';
 
-import {
-	TableNoResults,
-	TableNoResultsTitle,
-	FlexDiv,
-	Tooltip,
-	FlexDivCentered,
-} from 'styles/common';
+import { TableNoResults, TableNoResultsTitle, FlexDiv, Tooltip } from 'styles/common';
 import media from 'styles/media';
 
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
@@ -76,7 +70,7 @@ const ResponsiveDebtPoolTable: FC<ResponsiveDebtPoolTableProps> = ({
 	const { t } = useTranslation();
 
 	const { selectedPriceCurrency, selectPriceCurrencyRate } = useSelectedPriceCurrency();
-	const { connectWallet, isAppReady, isWalletConnected } = Connector.useContainer();
+	const { isAppReady, isWalletConnected } = Connector.useContainer();
 
 	const [renBTCBalance, wBTCBalance, wETHBalance, ETHBalance] = useMemo(
 		() => [

--- a/sections/debt/components/PortfolioTable/PortfolioTable.tsx
+++ b/sections/debt/components/PortfolioTable/PortfolioTable.tsx
@@ -18,7 +18,6 @@ import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import Table from 'components/Table';
 import Currency from 'components/Currency';
 import SynthHolding from 'components/SynthHolding';
-import Button from 'components/Button';
 
 import { ProgressBarType } from 'components/ProgressBar/ProgressBar';
 
@@ -29,6 +28,7 @@ import { DesktopOrTabletView, MobileOnlyView } from 'components/Media';
 import Info from 'assets/svg/app/info.svg';
 import { CryptoBalance } from 'hooks/useCryptoBalances';
 import { SynthsTotalSupplyData } from '@synthetixio/queries';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 const SHOW_HEDGING_INDICATOR_THRESHOLD = wei(0.1);
 
@@ -272,13 +272,7 @@ const ResponsiveDebtPoolTable: FC<ResponsiveDebtPoolTableProps> = ({
 	]);
 
 	if (!isWalletConnected) {
-		return (
-			<DefaultContainer>
-				<Button variant="primary" onClick={connectWallet}>
-					{t('common.wallet.connect-wallet')}
-				</Button>
-			</DefaultContainer>
-		);
+		return <ConnectOrSwitchNetwork />;
 	}
 
 	return (
@@ -363,11 +357,6 @@ const TooltipIconContainer = styled(FlexDiv)`
 
 const Strong = styled.strong`
 	font-family: ${(props) => props.theme.fonts.interBold};
-`;
-
-const DefaultContainer = styled(FlexDivCentered)`
-	width: 100%;
-	justify-content: center;
 `;
 
 export default DebtPoolTable;

--- a/sections/delegate/DelegateForm.tsx
+++ b/sections/delegate/DelegateForm.tsx
@@ -53,8 +53,7 @@ const DelegateForm: FC = () => {
 
 const Tab: FC = () => {
 	const { t } = useTranslation();
-	const { connectWallet, synthetixjs, isAppReady, isWalletConnected, walletAddress } =
-		Connector.useContainer();
+	const { synthetixjs, isAppReady, isWalletConnected, walletAddress } = Connector.useContainer();
 
 	const { useGetDelegateWallets, useSynthetixTxn } = useSynthetixQueries();
 

--- a/sections/earn/IncentivesTable.tsx
+++ b/sections/earn/IncentivesTable.tsx
@@ -293,9 +293,7 @@ const IncentivesInnerTable: FC<IncentivesInnerTableProps> = ({
 	isLoaded,
 	activeTab,
 }) => {
-	const { t } = useTranslation();
-
-	const { connectWallet, isWalletConnected } = Connector.useContainer();
+	const { isWalletConnected } = Connector.useContainer();
 	const router = useRouter();
 
 	return (

--- a/sections/earn/IncentivesTable.tsx
+++ b/sections/earn/IncentivesTable.tsx
@@ -10,7 +10,6 @@ import Currency from 'components/Currency';
 
 import ProgressBar from 'components/ProgressBar';
 import Table from 'components/Table';
-import Button from 'components/Button';
 
 import ExpandIcon from 'assets/svg/app/expand.svg';
 
@@ -18,14 +17,7 @@ import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 
 import { formatPercent, formatFiatCurrency, formatCurrency } from 'utils/formatters/number';
 
-import {
-	FlexDivCol,
-	GlowingCircle,
-	IconButton,
-	TableNoResults,
-	TableNoResultsButtonContainer,
-	TableNoResultsTitle,
-} from 'styles/common';
+import { FlexDivCol, GlowingCircle, IconButton, TableNoResults } from 'styles/common';
 import { CryptoCurrency, CurrencyKey } from 'constants/currency';
 import { DURATION_SEPARATOR } from 'constants/date';
 
@@ -35,6 +27,7 @@ import { LP, Tab } from './types';
 import { CurrencyIconType } from 'components/Currency/CurrencyIcon/CurrencyIcon';
 import { DesktopOrTabletView, MobileOnlyView } from 'components/Media';
 import Wei, { wei } from '@synthetixio/wei';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 export type DualRewards = {
 	a: Wei;
@@ -323,12 +316,7 @@ const IncentivesInnerTable: FC<IncentivesInnerTableProps> = ({
 			noResultsMessage={
 				!isWalletConnected ? (
 					<TableNoResults>
-						<TableNoResultsTitle>{t('common.wallet.no-wallet-connected')}</TableNoResultsTitle>
-						<TableNoResultsButtonContainer>
-							<Button variant="primary" onClick={connectWallet}>
-								{t('common.wallet.connect-wallet')}
-							</Button>
-						</TableNoResultsButtonContainer>
+						<ConnectOrSwitchNetwork />
 					</TableNoResults>
 				) : undefined
 			}

--- a/sections/history/TransactionsContainer.tsx
+++ b/sections/history/TransactionsContainer.tsx
@@ -16,7 +16,6 @@ import {
 	CapitalizedText,
 	GridDiv,
 	TableNoResults,
-	TableNoResultsTitle,
 	TableNoResultsButtonContainer,
 } from 'styles/common';
 
@@ -30,10 +29,11 @@ import {
 
 import CustomTypeOption from './CustomTypeOption';
 import { StakingTransactionType } from '@synthetixio/queries';
+import ConnectOrSwitchNetwork from '../../components/ConnectOrSwitchNetwork';
 
 const TransactionsContainer: FC<TransactionsContainerProps> = ({ history, isLoaded }) => {
 	const { t } = useTranslation();
-	const { connectWallet, isWalletConnected } = Connector.useContainer();
+	const { isWalletConnected } = Connector.useContainer();
 
 	const [typeFilter, setTypeFilter] = useState<ValueType<TypeFilterOptionType>>();
 	const [dateFilter, setDateFilter] = useState<{
@@ -224,12 +224,7 @@ const TransactionsContainer: FC<TransactionsContainerProps> = ({ history, isLoad
 				noResultsMessage={
 					!isWalletConnected ? (
 						<TableNoResults>
-							<TableNoResultsTitle>{t('common.wallet.no-wallet-connected')}</TableNoResultsTitle>
-							<TableNoResultsButtonContainer>
-								<Button variant="primary" onClick={connectWallet}>
-									{t('common.wallet.connect-wallet')}
-								</Button>
-							</TableNoResultsButtonContainer>
+							<ConnectOrSwitchNetwork />
 						</TableNoResults>
 					) : isLoaded && filtersEnabled && filteredTransactions.length === 0 ? (
 						<TableNoResults>

--- a/sections/loans/components/ActionBox/BorrowSynthsTab/FormButton.tsx
+++ b/sections/loans/components/ActionBox/BorrowSynthsTab/FormButton.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Trans, useTranslation } from 'react-i18next';
 import Button from 'components/Button';
 import { NoTextTransform } from 'styles/common';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 type FormButtonProps = {
 	collateralAsset: string;
@@ -31,11 +32,7 @@ const FormButton: React.FC<FormButtonProps> = ({
 }) => {
 	const { t } = useTranslation();
 	if (!isWalletConnected) {
-		return (
-			<StyledCTA variant="primary" size="lg" onClick={onClick}>
-				{t('common.wallet.connect-wallet')}
-			</StyledCTA>
-		);
+		return <ConnectOrSwitchNetwork />;
 	}
 	return (
 		<StyledCTA

--- a/sections/loans/components/ActionBox/BorrowSynthsTab/FormButton.tsx
+++ b/sections/loans/components/ActionBox/BorrowSynthsTab/FormButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import Button from 'components/Button';
 import { NoTextTransform } from 'styles/common';
 import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
@@ -30,7 +30,6 @@ const FormButton: React.FC<FormButtonProps> = ({
 	onClick,
 	hasBothInputsSet,
 }) => {
-	const { t } = useTranslation();
 	if (!isWalletConnected) {
 		return <ConnectOrSwitchNetwork />;
 	}

--- a/sections/loans/components/ActionBox/components/Balance.tsx
+++ b/sections/loans/components/ActionBox/components/Balance.tsx
@@ -91,9 +91,10 @@ const ERC20: React.FC<ERC20Props> = ({ asset, onSetMaxAmount }) => {
 	};
 
 	const contract = useMemo(() => {
+		if (!synthetixjs) return null;
 		const {
 			contracts: { ProxysBTC: sBTC, ProxysETH: sETH, ProxyERC20sUSD: sUSD },
-		} = synthetixjs!;
+		} = synthetixjs;
 		const tokens: Record<string, typeof sBTC> = {
 			sBTC,
 			sETH,

--- a/sections/loans/components/InfoBox/InfoBox.tsx
+++ b/sections/loans/components/InfoBox/InfoBox.tsx
@@ -56,7 +56,7 @@ const InfoBox: React.FC = () => {
 					ExchangeRates: exchangeRatesContract,
 					CollateralManager: collateralManagerContract,
 				},
-			} = synthetixjs!;
+			} = synthetixjs;
 
 			const getBorrowStats = async (currency: string) => {
 				const [openInterest, [assetUSDPrice]] = await Promise.all([

--- a/sections/merge-accounts/burn/BurnActionBox.tsx
+++ b/sections/merge-accounts/burn/BurnActionBox.tsx
@@ -39,6 +39,7 @@ import { getStakingAmount } from 'sections/staking/components/helper';
 import useBurnTx from 'sections/staking/hooks/useBurnTx';
 
 import { TxWaiting, TxSuccess } from './Tx';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 const BurnTab: FC = () => {
 	const { t } = useTranslation();
@@ -116,11 +117,7 @@ const BurnTabInner: FC = () => {
 
 	const returnButtonStates = useMemo(() => {
 		if (!isWalletConnected) {
-			return (
-				<StyledCTA variant="primary" size="lg" onClick={connectWallet}>
-					{t('common.wallet.connect-wallet')}
-				</StyledCTA>
-			);
+			return <ConnectOrSwitchNetwork />;
 		} else if (error) {
 			return (
 				<StyledCTA variant="primary" size="lg" disabled={true}>
@@ -139,7 +136,7 @@ const BurnTabInner: FC = () => {
 				</StyledCTA>
 			);
 		}
-	}, [error, txn.txnStatus, t, isWalletConnected, connectWallet, onBurn]);
+	}, [error, txn.txnStatus, isWalletConnected, onBurn]);
 
 	if (txn.txnStatus === 'pending') {
 		return <TxWaiting {...{ unstakeAmount, burnAmount: burnAmountUi, txLink }} />;

--- a/sections/merge-accounts/burn/BurnActionBox.tsx
+++ b/sections/merge-accounts/burn/BurnActionBox.tsx
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 import { Trans, useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
 import Wei, { wei } from '@synthetixio/wei';
-
-import Connector from 'containers/Connector';
 import StructuredTab from 'components/StructuredTab';
 import Etherscan from 'containers/BlockExplorer';
 import NavigationBack from 'assets/svg/app/navigation-back.svg';
@@ -60,7 +58,6 @@ const BurnTab: FC = () => {
 
 const BurnTabInner: FC = () => {
 	const { t } = useTranslation();
-	const { connectWallet } = Connector.useContainer();
 
 	const router = useRouter();
 	const { blockExplorerInstance } = Etherscan.useContainer();

--- a/sections/merge-accounts/merge/MergeActionBox.tsx
+++ b/sections/merge-accounts/merge/MergeActionBox.tsx
@@ -33,6 +33,7 @@ import {
 import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
 import WalletIcon from 'assets/svg/app/wallet-purple.svg';
 import { TxWaiting, TxSuccess } from './Tx';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 const MergeTab: FC = () => {
 	const { t } = useTranslation();
@@ -278,19 +279,14 @@ const MergeTabInner: FC = () => {
 					</SettingContainer>
 				</SettingsContainer>
 			</FormContainer>
-
-			<FormButton
-				onClick={connectOrMerge}
-				variant="primary"
-				size="lg"
-				data-testid="form-button"
-				disabled={
-					isWalletConnected && (!properSourceAccountAddress || !!sourceAccountAddressInputError)
-				}
-			>
-				{!isWalletConnected ? (
-					t('common.wallet.connect-wallet')
-				) : (
+			{isWalletConnected ? (
+				<FormButton
+					onClick={connectOrMerge}
+					variant="primary"
+					size="lg"
+					data-testid="form-button"
+					disabled={!properSourceAccountAddress || !!sourceAccountAddressInputError}
+				>
 					<Trans
 						i18nKey={`merge-accounts.merge.button-labels.${
 							txModalOpen
@@ -303,8 +299,10 @@ const MergeTabInner: FC = () => {
 						}`}
 						components={[<NoTextTransform />]}
 					/>
-				)}
-			</FormButton>
+				</FormButton>
+			) : (
+				<ConnectOrSwitchNetwork />
+			)}
 
 			{!txn.error ? null : <ErrorMessage>{txn.errorMessage}</ErrorMessage>}
 

--- a/sections/merge-accounts/merge/MergeActionBox.tsx
+++ b/sections/merge-accounts/merge/MergeActionBox.tsx
@@ -135,10 +135,10 @@ const MergeTabInner: FC = () => {
 
 	// load any nominated account address
 	useEffect(() => {
-		if (!isAppReady) return;
+		if (!isAppReady || !synthetixjs) return;
 		const {
 			contracts: { RewardEscrowV2 },
-		} = synthetixjs!;
+		} = synthetixjs;
 		if (!properSourceAccountAddress) return;
 
 		let isMounted = true;
@@ -184,10 +184,10 @@ const MergeTabInner: FC = () => {
 
 	// load nominated account address
 	useEffect(() => {
-		if (!isAppReady) return;
+		if (!isAppReady || !synthetixjs) return;
 		const {
 			contracts: { RewardEscrowV2 },
-		} = synthetixjs!;
+		} = synthetixjs;
 		if (!properSourceAccountAddress) return;
 
 		let isMounted = true;

--- a/sections/merge-accounts/nominate/NominateActionBox.tsx
+++ b/sections/merge-accounts/nominate/NominateActionBox.tsx
@@ -35,6 +35,7 @@ import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
 import WalletIcon from 'assets/svg/app/wallet-purple.svg';
 import ROUTES from 'constants/routes';
 import { TxWaiting, TxSuccess } from './Tx';
+import ConnectOrSwitchNetwork from '../../../components/ConnectOrSwitchNetwork';
 
 const NominateTab: FC = () => {
 	const { t } = useTranslation();
@@ -103,10 +104,10 @@ const NominateTabInner: FC = () => {
 
 	// load any previously nominated account address
 	useEffect(() => {
-		if (!isAppReady) return;
+		if (!isAppReady || !synthetixjs) return;
 		const {
 			contracts: { RewardEscrowV2 },
-		} = synthetixjs!;
+		} = synthetixjs;
 		if (!sourceAccountAddress) return;
 
 		let isMounted = true;
@@ -232,20 +233,14 @@ const NominateTabInner: FC = () => {
 					</SettingContainer>
 				</SettingsContainer>
 			</FormContainer>
-
-			<FormButton
-				onClick={connectOrBurnOrNominate}
-				variant="primary"
-				size="lg"
-				data-testid="form-button"
-				disabled={
-					isWalletConnected &&
-					(!properDestinationAccountAddress || !!destinationAccountAddressInputError)
-				}
-			>
-				{!isWalletConnected ? (
-					t('common.wallet.connect-wallet')
-				) : (
+			{isWalletConnected ? (
+				<FormButton
+					onClick={connectOrBurnOrNominate}
+					variant="primary"
+					size="lg"
+					data-testid="form-button"
+					disabled={!properDestinationAccountAddress || !!destinationAccountAddressInputError}
+				>
 					<Trans
 						i18nKey={`merge-accounts.nominate.button-labels.${
 							txModalOpen
@@ -258,8 +253,10 @@ const NominateTabInner: FC = () => {
 						}`}
 						components={[<NoTextTransform />]}
 					/>
-				)}
-			</FormButton>
+				</FormButton>
+			) : (
+				<ConnectOrSwitchNetwork />
+			)}
 
 			{!txn.error ? null : <ErrorMessage>{txn.errorMessage}</ErrorMessage>}
 

--- a/sections/shared/Layout/UserMenu/UserMenu.tsx
+++ b/sections/shared/Layout/UserMenu/UserMenu.tsx
@@ -102,7 +102,9 @@ const UserMenu: FC = () => {
 										<FlexDivCentered>
 											<StyledConnectionDot />
 											<UpperCased>
-												{signer ? t('unsupported-network') : t('common.wallet.not-connected')}
+												{signer
+													? t('common.wallet.unsupported-network')
+													: t('common.wallet.not-connected')}
 											</UpperCased>
 										</FlexDivCentered>
 										{walletOptionsModalOpened ? <CaretUp width="10" /> : <CaretDown width="10" />}

--- a/sections/shared/Layout/UserMenu/UserMenu.tsx
+++ b/sections/shared/Layout/UserMenu/UserMenu.tsx
@@ -41,7 +41,7 @@ const UserMenu: FC = () => {
 	const { t } = useTranslation();
 	const { networkError } = UI.useContainer();
 
-	const { network, ensName, ensAvatar, isWalletConnected, walletAddress } =
+	const { network, ensName, ensAvatar, isWalletConnected, walletAddress, signer } =
 		Connector.useContainer();
 
 	const [walletOptionsModalOpened, setWalletOptionsModalOpened] = useState<boolean>(false);
@@ -101,7 +101,9 @@ const UserMenu: FC = () => {
 									>
 										<FlexDivCentered>
 											<StyledConnectionDot />
-											<UpperCased>{t('common.wallet.not-connected')}</UpperCased>
+											<UpperCased>
+												{signer ? t('unsupported-network') : t('common.wallet.not-connected')}
+											</UpperCased>
 										</FlexDivCentered>
 										{walletOptionsModalOpened ? <CaretUp width="10" /> : <CaretDown width="10" />}
 									</WalletButton>

--- a/sections/shared/modals/WalletOptionsModal/WalletOptionsModal.tsx
+++ b/sections/shared/modals/WalletOptionsModal/WalletOptionsModal.tsx
@@ -121,6 +121,7 @@ const WalletOptionsModal: FC<WalletOptionsProps> = ({
 					<StyledButton
 						onClick={() => {
 							switchNetwork(NetworkIdByName.mainnet);
+							onDismiss();
 						}}
 					>
 						{t('modals.wallet.network.ethereum')}
@@ -129,6 +130,7 @@ const WalletOptionsModal: FC<WalletOptionsProps> = ({
 					<StyledButton
 						onClick={() => {
 							switchNetwork(NetworkIdByName['mainnet-ovm']);
+							onDismiss();
 						}}
 					>
 						{t('modals.wallet.network.optimism')}

--- a/sections/shared/modals/WalletOptionsModal/WalletOptionsModal.tsx
+++ b/sections/shared/modals/WalletOptionsModal/WalletOptionsModal.tsx
@@ -39,6 +39,7 @@ import {
 	Divider,
 } from 'styles/common';
 import { truncateAddress } from 'utils/formatters/string';
+import { NetworkIdByName } from '@synthetixio/contracts-interface';
 
 export type WalletOptionsProps = {
 	onDismiss: () => void;
@@ -96,6 +97,8 @@ const WalletOptionsModal: FC<WalletOptionsProps> = ({
 		isWalletConnected,
 		walletWatched,
 		walletType,
+		switchNetwork,
+		walletConnectedToUnsupportedNetwork,
 		stopWatching,
 	} = Connector.useContainer();
 	const { blockExplorerInstance } = Etherscan.useContainer();
@@ -110,6 +113,30 @@ const WalletOptionsModal: FC<WalletOptionsProps> = ({
 			}, 3000); // 3s
 		}
 	}, [copiedAddress]);
+
+	if (walletConnectedToUnsupportedNetwork) {
+		return (
+			<WalletDetails>
+				<Buttons>
+					<StyledButton
+						onClick={() => {
+							switchNetwork(NetworkIdByName.mainnet);
+						}}
+					>
+						{t('modals.wallet.network.ethereum')}
+					</StyledButton>
+					<DividerText>{t('common.wallet.or')}</DividerText>
+					<StyledButton
+						onClick={() => {
+							switchNetwork(NetworkIdByName['mainnet-ovm']);
+						}}
+					>
+						{t('modals.wallet.network.optimism')}
+					</StyledButton>
+				</Buttons>
+			</WalletDetails>
+		);
+	}
 
 	return (
 		<>

--- a/sections/shared/modals/WalletOptionsModal/index.tsx
+++ b/sections/shared/modals/WalletOptionsModal/index.tsx
@@ -19,7 +19,7 @@ export const DesktopWalletOptionsModal: FC<WalletOptionsProps> = ({
 	const { t } = useTranslation();
 
 	return (
-		<DesktopStyledMenuModal {...{ onDismiss }} title={t('modals.wallet.watch-wallet.title')}>
+		<DesktopStyledMenuModal title={t('modals.wallet.watch-wallet.title')}>
 			<Modal
 				{...{
 					onDismiss,

--- a/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
+++ b/sections/staking/components/SelfLiquidateTab/SelfLiquidateTab.tsx
@@ -6,19 +6,17 @@ import { useRecoilValue } from 'recoil';
 import { TabContainer } from 'sections/staking/components/common';
 import useStakingCalculations from 'sections/staking/hooks/useStakingCalculations';
 import { delegateWalletState } from 'store/wallet';
-import { useTranslation } from 'react-i18next';
 import SelfLiquidationTabContent from './SelfLiquidationTabContent';
-import { StyledCTA } from 'sections/staking/components/common';
 import Connector from 'containers/Connector';
 import styled from 'styled-components';
 import { FlexDivJustifyCenter } from 'styles/common';
 import Loader from 'components/Loader';
 import useGetCanBurn from 'hooks/useGetCanBurn';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 const SelfLiquidateTab = () => {
-	const { connectWallet, walletAddress } = Connector.useContainer();
+	const { walletAddress, isWalletConnected } = Connector.useContainer();
 
-	const { t } = useTranslation();
 	const {
 		debtBalance,
 		issuableSynths,
@@ -53,12 +51,10 @@ const SelfLiquidateTab = () => {
 	);
 
 	const burnAmountToFixCRatio = wei(Wei.max(debtBalance.sub(issuableSynths), wei(0)));
-	if (!walletAddress) {
+	if (!isWalletConnected || !walletAddress) {
 		return (
 			<ConnectWalletButtonWrapper>
-				<StyledCTA variant="primary" size="lg" onClick={connectWallet}>
-					{t('common.wallet.connect-wallet')}
-				</StyledCTA>
+				<ConnectOrSwitchNetwork />
 			</ConnectWalletButtonWrapper>
 		);
 	}
@@ -96,7 +92,7 @@ const SelfLiquidateTab = () => {
 	);
 };
 const ConnectWalletButtonWrapper = styled.div`
-	width: 200px;
+	width: 250px;
 	margin: 0 auto;
 `;
 export default SelfLiquidateTab;

--- a/sections/staking/components/StakingInput/StakingInput.tsx
+++ b/sections/staking/components/StakingInput/StakingInput.tsx
@@ -48,6 +48,7 @@ import Button from 'components/Button';
 import Currency from 'components/Currency';
 import { parseSafeWei } from 'utils/parse';
 import { GasPrice } from '@synthetixio/queries';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 type StakingInputProps = {
 	onSubmit: () => void;
@@ -119,7 +120,7 @@ const StakingInput: React.FC<StakingInputProps> = ({
 }) => {
 	const { targetCRatio, SNXRate, debtBalance, issuableSynths, collateral, currentCRatio } =
 		useStakingCalculations();
-	const { connectWallet, isWalletConnected } = Connector.useContainer();
+	const { isWalletConnected } = Connector.useContainer();
 	const burnType = useRecoilValue(burnTypeState);
 	const { t } = useTranslation();
 
@@ -145,25 +146,24 @@ const StakingInput: React.FC<StakingInputProps> = ({
 
 	const returnButtonStates = useMemo(() => {
 		if (!isWalletConnected) {
-			return (
-				<StyledCTA variant="primary" size="lg" onClick={connectWallet}>
-					{t('common.wallet.connect-wallet')}
-				</StyledCTA>
-			);
-		} else if (error) {
+			return <ConnectOrSwitchNetwork />;
+		}
+		if (error) {
 			if (!errorIsClearable(error)) return null;
 			return (
 				<StyledCTA variant="primary" size="lg" onClick={() => resetTransaction()}>
 					{t('common.error.clear')}
 				</StyledCTA>
 			);
-		} else if (inputValue.toString().length === 0) {
+		}
+		if (inputValue.toString().length === 0) {
 			return (
 				<StyledCTA variant="primary" size="lg" disabled={true}>
 					{isMint ? t('staking.actions.mint.action.empty') : t('staking.actions.burn.action.empty')}
 				</StyledCTA>
 			);
-		} else if (
+		}
+		if (
 			burnType === BurnActionType.TARGET &&
 			maxBurnAmount != null &&
 			burnAmountToFixCRatio != null &&
@@ -177,7 +177,8 @@ const StakingInput: React.FC<StakingInputProps> = ({
 					/>
 				</StyledCTA>
 			);
-		} else if (burnType === BurnActionType.CLEAR) {
+		}
+		if (burnType === BurnActionType.CLEAR) {
 			return (
 				<StyledCTA
 					onClick={onSubmit}
@@ -188,23 +189,20 @@ const StakingInput: React.FC<StakingInputProps> = ({
 					{t('staking.actions.burn.action.clear-debt')}
 				</StyledCTA>
 			);
-		} else {
-			return (
-				<StyledCTA
-					onClick={onSubmit}
-					variant="primary"
-					size="lg"
-					disabled={transactionState !== 'unsent'}
-				>
-					<Trans
-						i18nKey={
-							isMint ? 'staking.actions.mint.action.mint' : 'staking.actions.burn.action.burn'
-						}
-						components={[<NoTextTransform />]}
-					/>
-				</StyledCTA>
-			);
 		}
+		return (
+			<StyledCTA
+				onClick={onSubmit}
+				variant="primary"
+				size="lg"
+				disabled={transactionState !== 'unsent'}
+			>
+				<Trans
+					i18nKey={isMint ? 'staking.actions.mint.action.mint' : 'staking.actions.burn.action.burn'}
+					components={[<NoTextTransform />]}
+				/>
+			</StyledCTA>
+		);
 	}, [
 		isWalletConnected,
 		error,
@@ -212,7 +210,6 @@ const StakingInput: React.FC<StakingInputProps> = ({
 		burnType,
 		maxBurnAmount,
 		burnAmountToFixCRatio,
-		connectWallet,
 		t,
 		resetTransaction,
 		isMint,
@@ -349,7 +346,7 @@ const StakingInput: React.FC<StakingInputProps> = ({
 					</DataRow>
 				</DataContainer>
 			</InputContainer>
-			<ErrorParagraph>{error}</ErrorParagraph>
+			{isWalletConnected && <ErrorParagraph>{error}</ErrorParagraph>}
 			{returnButtonStates}
 			{txModalOpen && (
 				<TxConfirmationModal

--- a/sections/synths/components/DesktopAssetsTable.tsx
+++ b/sections/synths/components/DesktopAssetsTable.tsx
@@ -36,6 +36,7 @@ import { isSynth } from 'utils/currencies';
 import SynthPriceCol from './SynthPriceCol';
 import { StyledButtonBlue, StyledButtonPink } from './common';
 import { CurrencyKey } from '@synthetixio/contracts-interface';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 type AssetsTableProps = {
 	assets: CryptoBalance[];
@@ -65,8 +66,7 @@ const AssetsTable: FC<AssetsTableProps> = ({
 	showPrice = true,
 }) => {
 	const { t } = useTranslation();
-	const { connectWallet, synthsMap, isAppReady, isL2, isWalletConnected } =
-		Connector.useContainer();
+	const { synthsMap, isAppReady, isL2, isWalletConnected } = Connector.useContainer();
 
 	const router = useRouter();
 
@@ -239,12 +239,7 @@ const AssetsTable: FC<AssetsTableProps> = ({
 			noResultsMessage={
 				!isWalletConnected ? (
 					<TableNoResults>
-						<TableNoResultsTitle>{t('common.wallet.no-wallet-connected')}</TableNoResultsTitle>
-						<TableNoResultsButtonContainer>
-							<Button variant="primary" onClick={connectWallet}>
-								{t('common.wallet.connect-wallet')}
-							</Button>
-						</TableNoResultsButtonContainer>
+						<ConnectOrSwitchNetwork />
 					</TableNoResults>
 				) : isLoaded && assets.length === 0 ? (
 					<TableNoResults>

--- a/sections/synths/components/MobileAssetsTable.tsx
+++ b/sections/synths/components/MobileAssetsTable.tsx
@@ -34,6 +34,7 @@ import { isSynth } from 'utils/currencies';
 import SynthPriceCol from './SynthPriceCol';
 import { StyledButtonBlue, StyledButtonPink } from './common';
 import { CurrencyKey } from '@synthetixio/contracts-interface';
+import ConnectOrSwitchNetwork from 'components/ConnectOrSwitchNetwork';
 
 type AssetsTableProps = {
 	assets: CryptoBalance[];
@@ -62,8 +63,7 @@ const AssetsTable: FC<AssetsTableProps> = ({
 	showPrice = true,
 }) => {
 	const { t } = useTranslation();
-	const { connectWallet, synthsMap, isAppReady, isL2, isWalletConnected } =
-		Connector.useContainer();
+	const { synthsMap, isAppReady, isL2, isWalletConnected } = Connector.useContainer();
 
 	const router = useRouter();
 
@@ -207,12 +207,7 @@ const AssetsTable: FC<AssetsTableProps> = ({
 			noResultsMessage={
 				!isWalletConnected ? (
 					<TableNoResults>
-						<TableNoResultsTitle>{t('common.wallet.no-wallet-connected')}</TableNoResultsTitle>
-						<TableNoResultsButtonContainer>
-							<Button variant="primary" onClick={connectWallet}>
-								{t('common.wallet.connect-wallet')}
-							</Button>
-						</TableNoResultsButtonContainer>
+						<ConnectOrSwitchNetwork />
 					</TableNoResults>
 				) : isLoaded && assets.length === 0 ? (
 					<TableNoResults>

--- a/sections/synths/components/RedeemableDeprecatedSynthsModal.tsx
+++ b/sections/synths/components/RedeemableDeprecatedSynthsModal.tsx
@@ -49,14 +49,15 @@ const RedeemDeprecatedSynthsModal: FC<{
 	const [txModalOpen, setTxModalOpen] = useState<boolean>(false);
 
 	const sUSDBalance = synthBalances?.balancesMap[Synths.sUSD]?.balance ?? wei(0);
-	const Redeemer = synthetixjs!.contracts.SynthRedeemer;
+	const Redeemer = synthetixjs?.contracts.SynthRedeemer ?? null;
 
 	const { useContractTxn } = useSynthetixQueries();
 	const txn = useContractTxn(
 		Redeemer,
 		'redeemAll',
 		[redeemableDeprecatedSynthsAddresses],
-		gasPrice
+		gasPrice,
+		{ enabled: Boolean(synthetixjs) }
 	);
 
 	const link = useMemo(

--- a/sections/synths/components/TransferModal.tsx
+++ b/sections/synths/components/TransferModal.tsx
@@ -49,7 +49,7 @@ const TransferModal: FC<TransferModalProps> = ({
 		setDestinationAddress((e.target.value ?? '').trim());
 
 	const contract =
-		synthetixjs!.contracts[
+		synthetixjs?.contracts[
 			isSynth(currentAsset?.currencyKey)
 				? synthToContractName(currentAsset?.currencyKey || '')
 				: 'Synthetix'
@@ -58,7 +58,7 @@ const TransferModal: FC<TransferModalProps> = ({
 	const transferAmountWei = parseSafeWei(amount, 0);
 
 	const txn = useContractTxn(
-		contract,
+		contract ?? null,
 		isSynth(currentAsset?.currencyKey) ? 'transferAndSettle' : 'transfer',
 		[
 			ethers.utils.isAddress(destinationAddress)

--- a/store/wallet/index.ts
+++ b/store/wallet/index.ts
@@ -7,8 +7,8 @@ import { getWalletKey } from '../utils';
 import { DelegationWallet } from '@synthetixio/queries';
 
 export type Network = {
-	id: NetworkId;
-	name: NetworkName;
+	id: NetworkId | number;
+	name: NetworkName | string;
 	useOvm: boolean;
 };
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -1228,6 +1228,7 @@
 			"connect-wallet": "connect wallet",
 			"no-wallet-connected": "No wallet connected",
 			"unsupported-network": "Unsupported Network",
+			"switch-to-supported": "Switch to a supported network:",
 			"balance": "Balance: {{balance}}",
 			"transferable": "<0>Transferable</0> {{transferable}}",
 			"not-connected": "Not connected",

--- a/translations/en.json
+++ b/translations/en.json
@@ -97,6 +97,10 @@
 			"stop-delegation": "Stop delegate mode",
 			"change-wallet": "change wallet",
 			"switch-account": "switch account",
+			"network": {
+				"ethereum": "Ethereum Mainnet",
+				"optimism": "Optimism Mainnet"
+			},
 			"available-on-hardware-wallet": "Available on hardware wallets",
 			"delegate-mode": {
 				"menu-title": "Delegate mode",
@@ -115,6 +119,7 @@
 					"remove": "Remove address"
 				}
 			},
+
 			"wallet-options": {
 				"title": "Please choose:"
 			}
@@ -1222,6 +1227,7 @@
 		"wallet": {
 			"connect-wallet": "connect wallet",
 			"no-wallet-connected": "No wallet connected",
+			"unsupported-network": "Unsupported Network",
 			"balance": "Balance: {{balance}}",
 			"transferable": "<0>Transferable</0> {{transferable}}",
 			"not-connected": "Not connected",


### PR DESCRIPTION
This PR adds support to be connected to an unsupported network. `synthetixjs` cannot be instantiated with an unsupported network. So we can now have a signer and still have `synthetixjs` be null.
This gives us two benefits:
1. The bridge page works with swapping from unsupported networks
2. We can render a UI letting the user know that they are on the wrong network.

Most of the logic is in the first commits. Then I just went through all pages and switched out `<Connect Wallet>` button to `<ConnectOrSwitchNetwork />`.

Sorry for large PR....
The header button now say "Unsupported network"  and render buttons for switching:
<img width="293" alt="Screen Shot 2022-08-11 at 2 14 08 pm" src="https://user-images.githubusercontent.com/5688912/184163014-133db65c-99b5-4dcb-96f9-61322d363f4d.png">

The bridge page works even when on an unsupported network:
<img width="1178" alt="Screen Shot 2022-08-11 at 2 13 48 pm" src="https://user-images.githubusercontent.com/5688912/184162922-3f2312dd-5c6d-4d68-b23e-35c5b4c610bf.png">

All other pages looks like this:

<img width="532" alt="Screen Shot 2022-08-11 at 3 49 27 pm" src="https://user-images.githubusercontent.com/5688912/184163251-aeea729d-dc8e-4765-8b2c-5199b38594aa.png">
<img width="560" alt="Screen Shot 2022-08-11 at 3 48 57 pm" src="https://user-images.githubusercontent.com/5688912/184163267-4f1389c4-503d-458e-b2f6-ef125875dd95.png">

I tried to test all different stage before committing and I have a bunch of more screenshots if you're interested hehe...
