### PR TITLE
Correct estimation when selling

### DIFF
--- a/constants/dhedge.ts
+++ b/constants/dhedge.ts
@@ -1,6 +1,7 @@
 import { Contract } from 'ethers';
 import { abi as erc20ABI } from 'contracts/erc20';
 import { abi as dHedgePoolLogicABI } from 'contracts/dHedgePoolLogic';
+import { wei } from '@synthetixio/wei';
 
 export const dHedgeAPIUrl = 'https://api-v2.dhedge.org/graphql';
 export const dSNXContractMainnet = new Contract(
@@ -17,3 +18,5 @@ export const dSNXWrapperSwapperContractOptimism = new Contract(
     'function withdrawSUSD(address pool, uint256 fundTokenAmount,address intermediateAsset,uint256 expectedAmountSUSD) external',
   ]
 );
+// this slippage is just use for estimation, the actual slippage might differ
+export const SLIPPAGE = wei(0.01);

--- a/sections/debt/components/ManageTab/BuyHedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/BuyHedgeTabOptimism.tsx
@@ -99,8 +99,7 @@ const BuyHedgeTabOptimism = () => {
       ? formatCryptoCurrency(
           wei(actualAmountToSendBn).sub(actualAmountToSendBn.mul(SLIPPAGE)).div(dSNXPrice),
           {
-            maxDecimals: 1,
-            minDecimals: 2,
+            minDecimals: 3,
           }
         )
       : '';
@@ -121,8 +120,7 @@ const BuyHedgeTabOptimism = () => {
             min={0}
             disabled={approveTx.isLoading || depositTx.isLoading}
             placeholder={formatCryptoCurrency(sUSDBalance, {
-              maxDecimals: 1,
-              minDecimals: 2,
+              minDecimals: 3,
             })}
             onChange={(e) => {
               try {
@@ -139,8 +137,7 @@ const BuyHedgeTabOptimism = () => {
         <StyledBalance>
           {t('debt.actions.manage.balance-usd')}
           {formatCryptoCurrency(wei(sUSDBalance), {
-            maxDecimals: 1,
-            minDecimals: 2,
+            minDecimals: 3,
           })}
           <StyledMaxButton
             variant="text"
@@ -169,15 +166,14 @@ const BuyHedgeTabOptimism = () => {
               type="text"
               onChange={() => {}}
               disabled
-              value={dSnxAmount ? `~${dSnxAmount}` : ''}
+              value={dSnxAmount ? `~${dSnxAmount}` : '~0'}
             />
           </InputWrapper>
         </Tooltip>
         <StyledBalance>
           {t('debt.actions.manage.balance')}
           {formatCryptoCurrency(dSNXBalance || wei(0), {
-            maxDecimals: 1,
-            minDecimals: 2,
+            minDecimals: 3,
           })}
         </StyledBalance>
         <GasSelector

--- a/sections/debt/components/ManageTab/BuyHedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/BuyHedgeTabOptimism.tsx
@@ -1,4 +1,4 @@
-import { dSNXPoolContractOptimism } from 'constants/dhedge';
+import { dSNXPoolContractOptimism, SLIPPAGE } from 'constants/dhedge';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { utils } from 'ethers';
@@ -8,6 +8,7 @@ import GasSelector from 'components/GasSelector';
 import { GasPrice } from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
 import {
+  InputWrapper,
   PoweredByContainer,
   StyledBackgroundTab,
   StyledBalance,
@@ -34,6 +35,7 @@ import {
   ModalItem,
   ModalItemText,
   ModalItemTitle,
+  Tooltip,
 } from 'styles/common';
 import { EXTERNAL_LINKS } from 'constants/links';
 import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
@@ -77,11 +79,11 @@ const BuyHedgeTabOptimism = () => {
   const sUSDBalance = synthsBalancesQuery.data?.balancesMap.sUSD?.balance || wei(0);
   const dSNXBalanceQuery = useGetDSnxBalance();
   const dSNXBalance = dSNXBalanceQuery.data;
-  const actualAmountToSendBn = sendMax ? sUSDBalance.toBN() : wei(amountToSend || 0).toBN();
+  const actualAmountToSendBn = sendMax ? sUSDBalance : wei(amountToSend || 0);
   const depositTx = useContractTxn(
     dSNXPoolContractOptimism,
     'deposit',
-    [sUSDContract?.address, actualAmountToSendBn],
+    [sUSDContract?.address, actualAmountToSendBn.toBN()],
     depositGasCost,
     {
       onSuccess: () => {
@@ -94,10 +96,13 @@ const BuyHedgeTabOptimism = () => {
   );
   const dSnxAmount =
     actualAmountToSendBn.gt(0) && dSNXPrice
-      ? formatCryptoCurrency(wei(actualAmountToSendBn).div(dSNXPrice), {
-          maxDecimals: 1,
-          minDecimals: 2,
-        })
+      ? formatCryptoCurrency(
+          wei(actualAmountToSendBn).sub(actualAmountToSendBn.mul(SLIPPAGE)).div(dSNXPrice),
+          {
+            maxDecimals: 1,
+            minDecimals: 2,
+          }
+        )
       : '';
 
   return (
@@ -110,25 +115,27 @@ const BuyHedgeTabOptimism = () => {
             sUSD
           </StyledCryptoCurrencyBox>
         </StyledInputLabel>
-        <StyledHedgeInput
-          type="number"
-          min={0}
-          disabled={approveTx.isLoading || depositTx.isLoading}
-          placeholder={formatCryptoCurrency(sUSDBalance, {
-            maxDecimals: 1,
-            minDecimals: 2,
-          })}
-          onChange={(e) => {
-            try {
-              const val = utils.parseUnits(e.target.value || '0', 18);
-              if (val.gte(constants.MaxUint256)) return;
-              setSendMax(false);
-              setAmountToSend(e.target.value);
-            } catch {}
-          }}
-          value={sendMax ? sUSDBalance.toString(2) : amountToSend}
-          autoFocus={true}
-        />
+        <InputWrapper>
+          <StyledHedgeInput
+            type="number"
+            min={0}
+            disabled={approveTx.isLoading || depositTx.isLoading}
+            placeholder={formatCryptoCurrency(sUSDBalance, {
+              maxDecimals: 1,
+              minDecimals: 2,
+            })}
+            onChange={(e) => {
+              try {
+                const val = utils.parseUnits(e.target.value || '0', 18);
+                if (val.gte(constants.MaxUint256)) return;
+                setSendMax(false);
+                setAmountToSend(e.target.value);
+              } catch {}
+            }}
+            value={sendMax ? sUSDBalance.toString(2) : amountToSend}
+            autoFocus={true}
+          />
+        </InputWrapper>
         <StyledBalance>
           {t('debt.actions.manage.balance-usd')}
           {formatCryptoCurrency(wei(sUSDBalance), {
@@ -156,12 +163,16 @@ const BuyHedgeTabOptimism = () => {
             dSNX
           </StyledCryptoCurrencyBox>
         </StyledInputLabel>
-        <StyledHedgeInput
-          type="text"
-          onChange={() => {}}
-          disabled
-          value={dSnxAmount ? `~${dSnxAmount}` : ''}
-        />
+        <Tooltip content={"This assumes a slippage of 1%, usually it's less than that"}>
+          <InputWrapper>
+            <StyledHedgeInput
+              type="text"
+              onChange={() => {}}
+              disabled
+              value={dSnxAmount ? `~${dSnxAmount}` : ''}
+            />
+          </InputWrapper>
+        </Tooltip>
         <StyledBalance>
           {t('debt.actions.manage.balance')}
           {formatCryptoCurrency(dSNXBalance || wei(0), {

--- a/sections/debt/components/ManageTab/SellHedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/SellHedgeTabOptimism.tsx
@@ -152,7 +152,7 @@ export default function SellHedgeTabOptimism() {
             isActive={dSNXBalanceQuery.data?.gt(0)}
             disabled={approveTx.isLoading || withdrawTx.isLoading}
             onClick={() => {
-              if (sUSDBalance?.gt(0)) {
+              if (dSNXBalanceQuery.data?.gt(0)) {
                 setSendMax(true);
               }
             }}

--- a/sections/debt/components/ManageTab/SellHedgeTabOptimism.tsx
+++ b/sections/debt/components/ManageTab/SellHedgeTabOptimism.tsx
@@ -72,10 +72,11 @@ export default function SellHedgeTabOptimism() {
   const dollarAmountToReceive =
     actualAmountToSendBn.gt(0) && dSNXPrice ? wei(actualAmountToSendBn).mul(dSNXPrice) : wei(0);
   const sUSDToReceiveWei = dollarAmountToReceive.sub(dollarAmountToReceive.mul(SLIPPAGE));
-  const sUSDAmountToReceive = formatCryptoCurrency(sUSDToReceiveWei, {
-    maxDecimals: 1,
-    minDecimals: 2,
-  });
+  const sUSDAmountToReceive = sUSDToReceiveWei.gt(0)
+    ? formatCryptoCurrency(sUSDToReceiveWei, {
+        minDecimals: 3,
+      })
+    : '0';
   const approveTx = useContractTxn(
     dSNXPoolContractOptimism.connect(signer!),
     'approve',
@@ -125,8 +126,7 @@ export default function SellHedgeTabOptimism() {
             min={0}
             disabled={approveTx.isLoading || withdrawTx.isLoading}
             placeholder={formatCryptoCurrency(dSNXBalanceQuery.data || wei(0), {
-              maxDecimals: 1,
-              minDecimals: 2,
+              minDecimals: 3,
             })}
             onChange={(e) => {
               try {
@@ -145,8 +145,7 @@ export default function SellHedgeTabOptimism() {
         <StyledBalance>
           Balance:&nbsp;
           {formatCryptoCurrency(wei(dSNXBalanceQuery.data || wei(0)), {
-            maxDecimals: 1,
-            minDecimals: 2,
+            minDecimals: 3,
           })}
           <StyledMaxButton
             variant="text"
@@ -176,7 +175,7 @@ export default function SellHedgeTabOptimism() {
               type="text"
               onChange={() => {}}
               disabled
-              value={sUSDAmountToReceive ? `~${sUSDAmountToReceive}` : ''}
+              value={sUSDAmountToReceive ? `~${sUSDAmountToReceive}` : '0'}
             />
           </InputWrapper>
         </Tooltip>
@@ -184,8 +183,7 @@ export default function SellHedgeTabOptimism() {
         <StyledBalance>
           Balance:&nbsp;
           {formatCryptoCurrency(sUSDBalance, {
-            maxDecimals: 1,
-            minDecimals: 2,
+            minDecimals: 3,
           })}
         </StyledBalance>
         <GasSelector

--- a/sections/debt/components/ManageTab/hedge-tab-ui-components.tsx
+++ b/sections/debt/components/ManageTab/hedge-tab-ui-components.tsx
@@ -20,6 +20,7 @@ export const StyledBalance = styled.div`
   font-family: ${(props) => props.theme.fonts.condensedMedium};
 `;
 export const StyledHedgeInput = styled(StyledInput)`
+  margin-top: 0;
   width: 350px;
 `;
 
@@ -80,4 +81,7 @@ export const PoweredByContainer = styled.div`
 export const TorosLogo = styled.img`
   height: 12px;
   margin-left: 10px;
+`;
+export const InputWrapper = styled.div`
+  margin-top: 16px;
 `;


### PR DESCRIPTION
- Also add slippage to the estimation
- And a tooltip explaining the slippage
- Make sure output 0 is render when no amount is added
- Use three decimals

![image](https://user-images.githubusercontent.com/5688912/186813925-179c1932-192b-4a41-b633-49148a6626a1.png)
![Screen Shot 2022-08-26 at 1 51 33 pm](https://user-images.githubusercontent.com/5688912/186813972-348e99bc-eefc-4df3-902e-8d1461ddf982.png)

![image](https://user-images.githubusercontent.com/5688912/186814004-2ba4c01e-2f2c-46bf-9f0b-4578f30bc55a.png)
