### PR TITLE
Network should be number

### DIFF
--- a/content/App.tsx
+++ b/content/App.tsx
@@ -44,7 +44,7 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
       document.querySelector('#global-loader')?.remove();
     } catch (_e) {}
   }, []);
-  const networkId = String(network?.id);
+  const networkId = network?.id || -1;
   return (
     <>
       <SynthetixQueryContextProvider

--- a/content/App.tsx
+++ b/content/App.tsx
@@ -44,7 +44,7 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
       document.querySelector('#global-loader')?.remove();
     } catch (_e) {}
   }, []);
-  const networkId = network?.id || -1;
+  const networkId = network?.id ? Number(network?.id) : -1;
   return (
     <>
       <SynthetixQueryContextProvider


### PR DESCRIPTION
This fixes an issue with gas price estimation. If network is a string [this](https://github.com/Synthetixio/js-monorepo/blob/master/packages/queries/src/queries/network/useEthGasPriceQuery.ts#L47) if statement evaluates to false and we're not getting a proper EIP1559 gas estimation